### PR TITLE
make plotmol take in categories

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
@@ -672,24 +672,31 @@ def _plot_with_plotmol(
         )
     else:
         # we run the scatterplot for every category instead
-        for i, (cat, pred_df) in enumerate(pd.DataFrame.from_dict({
-            "category" : categories,
-            "smiles" : smiles,
-            "calculated" : calculated,
-            "experimental" : experimental
-        }).groupby(by="category")):        
-                plotmol.scatter(
+        for i, (cat, pred_df) in enumerate(
+            pd.DataFrame.from_dict(
+                {
+                    "category": categories,
+                    "smiles": smiles,
+                    "calculated": calculated,
+                    "experimental": experimental,
+                }
+            ).groupby(by="category")
+        ):
+            plotmol.scatter(
                 figure=figure,
                 x=pred_df["experimental"],
                 y=pred_df["calculated"],
                 smiles=pred_df["smiles"],
                 marker="o",
                 marker_size=15,
-                marker_color=palette[i], # TODO make this work for i>20
+                marker_color=palette[i],  # TODO make this work for i>20
                 legend_label=f"{cat}",
-                custom_column_data={"experimental": pred_df["experimental"], "prediction": pred_df["calculated"]}
+                custom_column_data={
+                    "experimental": pred_df["experimental"],
+                    "prediction": pred_df["calculated"],
+                },
             )
-        
+
         figure.legend.location = "top_left"
         figure.legend.click_policy = "hide"
     figure.axis.axis_label_text_font_size = "20pt"


### PR DESCRIPTION
This PR enables plotting in `asap-alchemy predict` using categories. This is useful because now we can split a scatterplot (bokeh) by e.g. `MoleculeSet`. Some quick things to resolve (@jthorton let's discuss):
- I'm not sure how ligand names are fed through to show on hover. How can we do this in https://github.com/choderalab/asapdiscovery/pull/902/files#diff-2c6504537d692ede517731411104bfc35ecf6c2d78762d4e558da83c9a6a2b44R690?
- I'm failing to feed xy labels as kwargs. Any ideas how to do this? Looks like plotmol overwrites the labels somehow: https://github.com/choderalab/asapdiscovery/pull/902/files#diff-2c6504537d692ede517731411104bfc35ecf6c2d78762d4e558da83c9a6a2b44R698

One caveat to this approach is that uncertainty whiskers don't disappear when a category is hidden (using the legend). Can fix that in a later iteration!

## Status
- [ ] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
