### PR TITLE
switch to pIC50 view in HTML reports

### DIFF
--- a/asapdiscovery-modeling/asapdiscovery/modeling/protein_prep.py
+++ b/asapdiscovery-modeling/asapdiscovery/modeling/protein_prep.py
@@ -268,13 +268,13 @@ class ProteinPrepper(ProteinPrepperBase):
                 # load protein
                 prot = complex_target.to_combined_oemol()
 
-                # if self.align:
-                #     prot, _ = superpose_molecule(
-                #         self.align.to_combined_oemol(),
-                #         prot,
-                #         self.ref_chain,
-                #         self.active_site_chain,
-                #     )
+                if self.align:
+                    prot, _ = superpose_molecule(
+                        self.align.to_combined_oemol(),
+                        prot,
+                        self.ref_chain,
+                        self.active_site_chain,
+                    )
 
                 # mutate residues
                 if self.seqres_yaml:

--- a/asapdiscovery-modeling/asapdiscovery/modeling/protein_prep.py
+++ b/asapdiscovery-modeling/asapdiscovery/modeling/protein_prep.py
@@ -268,13 +268,13 @@ class ProteinPrepper(ProteinPrepperBase):
                 # load protein
                 prot = complex_target.to_combined_oemol()
 
-                if self.align:
-                    prot, _ = superpose_molecule(
-                        self.align.to_combined_oemol(),
-                        prot,
-                        self.ref_chain,
-                        self.active_site_chain,
-                    )
+                # if self.align:
+                #     prot, _ = superpose_molecule(
+                #         self.align.to_combined_oemol(),
+                #         prot,
+                #         self.ref_chain,
+                #         self.active_site_chain,
+                #     )
 
                 # mutate residues
                 if self.seqres_yaml:


### PR DESCRIPTION
@jthorton we should switch to pIC50 plotting by default. I know we want to have a toggled view between pIC50 and DG but this is a workable form for now, albeit not very elegantly written.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
