### PR TITLE
`ASAP-Alchemy`: Local charging

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/charge.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/charge.py
@@ -1,0 +1,98 @@
+from asapdiscovery.alchemy.schema.base import _SchemaBase
+from pydantic import Field
+from typing import Literal, Any
+import abc
+from asapdiscovery.data.schema.ligand import Ligand
+
+
+class _BaseChargeMethod(_SchemaBase, abc.ABC):
+
+    type: Literal["_BaseChargeMethod"] = "_BaseChargeMethod"
+
+    @abc.abstractmethod
+    def provenance(self) -> dict[str, Any]:
+        """Return the provenance for this pose generation method."""
+        ...
+
+    @abc.abstractmethod
+    def _generate_charges(
+            self,
+            ligands: list[Ligand],
+            processors: int = 1,
+    ) -> list[Ligand]:
+        """The main worker method which should be used to generate charges for the ligands."""
+        ...
+
+    def generate_charges(
+            self,
+            ligands: list[Ligand],
+            processors: int = 1
+    ) -> list[Ligand]:
+        return self._generate_charges(ligands=ligands, processors=processors)
+
+
+class OpenFFCharges(_BaseChargeMethod):
+
+    type: Literal["OpenFFCharges"] = "OpenFFCharges"
+
+    charge_method: Literal["am1bccelf10", "am1bcc"] = Field("am1bccelf10", description="The OpenFF toolkit supported "
+                                                                                       "charging method to use.")
+
+    def provenance(self) -> dict[str, Any]:
+        import openff.toolkit
+        provenance = {"openff.toolkit": openff.toolkit.__version__}
+        if self.charge_method == "am1bccelf10":
+            from openeye import oequacpac, oeomega
+            provenance["oeomega"] = oeomega.OEOmegaGetVersion()
+            provenance["oequacpac"] = oequacpac.OE_OEQUACPAC_VERSION
+        else:
+            import rdkit
+            from openff.utilities import get_ambertools_version
+            provenance["rdkit"] = rdkit.__version__
+            provenance["ambertools"] = get_ambertools_version()
+        return provenance
+
+    def _charge_molecule(self, ligand: Ligand) -> Ligand:
+        """Generate charges for the molecule using the openff toolkit."""
+        from openff.toolkit import Molecule
+        off_mol = Molecule.from_rdkit(ligand.to_rdkit())
+        off_mol.assign_partial_charges(partial_charge_method=self.charge_method)
+        # fake the creation of the rdkit double property list
+        charges = " ".join([str(e) for e in off_mol.partial_charges.m])
+        ligand.tags["atom.dprop.PartialCharge"] = charges
+        return ligand
+
+    def _generate_charges(
+            self,
+            ligands: list[Ligand],
+            processors: int = 1,
+    ) -> list[Ligand]:
+        from openff.toolkit import Molecule
+        from concurrent.futures import ProcessPoolExecutor, as_completed
+
+        charge_method = self.dict()
+        charge_method["provenance"] = self.provenance()
+        charged_ligands = []
+
+        if processors > 1:
+            with ProcessPoolExecutor(max_workers=processors) as pool:
+                work_list = [
+                    pool.submit(
+                        self._charge_molecule,
+                        ligand
+                    )
+                    for ligand in ligands
+                ]
+                for work in as_completed(work_list):
+                    result_ligand = work.result()
+                    charged_ligands.append(result_ligand)
+
+        else:
+            for ligand in ligands:
+                charged_ligands.append(self._charge_molecule(ligand=ligand))
+
+        for ligand in charged_ligands:
+            # stamp how the charges were made
+            ligand.tags["charge_generation"] = charge_method
+
+        return charged_ligands

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_alchemy_prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_alchemy_prep.py
@@ -35,6 +35,7 @@ def test_prep_workflow(strict_stereo, core_smarts, failed, mac1_complex):
         strict_stereo=strict_stereo,
         core_smarts=core_smarts,
         pose_generator=OpenEyeConstrainedPoseGenerator(),
+        charge_method=None
     )
 
     alchemy_dataset = workflow.create_alchemy_dataset(
@@ -142,6 +143,8 @@ def test_prep_workflow_ref_ligands(mac1_complex):
         core_smarts=None,
         # use small number of confs to keep the test fast
         pose_generator=RDKitConstrainedPoseGenerator(max_confs=10),
+        # turn off charging for speed
+        charge_method=None
     )
 
     experimental_data = {"cdd_protocol": "my-protocol", "experimental": "True"}
@@ -179,3 +182,43 @@ def test_prep_workflow_ref_ligands(mac1_complex):
     for mol in alchemy_dataset.posed_ligands:
         for key, value in experimental_data.items():
             assert mol.tags[key] == value
+
+
+def test_prep_with_charges(mac1_complex):
+    """Test running the prep workflow and generating charges"""
+
+    # no access to epik so skip
+    workflow = AlchemyPrepWorkflow(
+        charge_expander=None,
+        strict_stereo=True,
+        core_smarts=None,
+        # use small number of confs to keep the test fast
+        pose_generator=RDKitConstrainedPoseGenerator(max_confs=10),
+    )
+
+    alchemy_dataset = workflow.create_alchemy_dataset(
+        dataset_name="mac1-testing-dataset",
+        ligands=[
+            Ligand.from_smiles(
+                "Cc1c(cn(n1)C)c2cc3c([nH]2)ncnc3N[C@H](c4ccc5c(c4)S(=O)(=O)CCC5)C(C)C",
+                compound_name="stereo_mol",
+            )
+        ],
+        reference_complex=mac1_complex,
+    )
+    # check we have the expected number of outputs
+    assert len(alchemy_dataset.input_ligands) == 1
+    assert len(alchemy_dataset.posed_ligands) == 1
+    # make sure charges were generated, name must be this to be found by openfe and openff
+    assert "atom.dprop.PartialCharge" in alchemy_dataset.posed_ligands[0].tags
+    # mock the BFE workflow passing the charges to openfe  then openff and make sure they match
+    openfe_mol = alchemy_dataset.posed_ligands[0].to_openfe()
+    off_mol = openfe_mol.to_openff()
+    assert off_mol.partial_charges is not None
+    # make sure the charges are consistent
+    for i, charge in enumerate(alchemy_dataset.posed_ligands[0].tags["atom.dprop.PartialCharge"].split(" ")):
+        assert float(charge) == off_mol.partial_charges[i].m
+    # make sure the method was stamped on the molecule
+    method_data = workflow.charge_method.dict()
+    method_data["provenance"] = workflow.charge_method.provenance()
+    assert alchemy_dataset.posed_ligands[0].tags["charge_generation"] == method_data

--- a/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
@@ -293,6 +293,11 @@ class Ligand(DataModelAbstractBase):
         # dump tags as separate items
         if self.tags is not None:
             data.update({k: v for k, v in self.tags.items()})
+        # if we have partial charges set them on the atoms assuming the atom ordering is not changed
+        if "atom.dprop.PartialCharge" in self.tags:
+            for i, charge in enumerate(self.tags["atom.dprop.PartialCharge"].split(" ")):
+                atom = rdkit_mol.GetAtomWithIdx(i)
+                atom.SetDoubleProp("PartialCharge", float(charge))
 
         # set the SD that is different for each conformer
         # convert to str first


### PR DESCRIPTION
## Description
This PR implements #974 by adding local charging to the alchemy prep workflow. By default, charges are generated using the openeye am1bccelf10 method, this is also modular so we can add other charging methods in future like NAGL or even RESP based methods. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [ ]  ensure charges are passed to openfe/openff
- [ ] add charge section to the docs

## Questions
- [ ] Question 1 ..

## Status
- [ ] Ready to go


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
