### PR TITLE
`ASAP-Alchemy`: Make the alchemiscale helper more flexible

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -252,7 +252,7 @@ def submit(
 
     # launch the helper which will try to login
     click.echo("Connecting to Alchemiscale...")
-    client = AlchemiscaleHelper()
+    client = AlchemiscaleHelper.from_settings()
     # create the scope
     network_scope = Scope(org=organization, campaign=campaign, project=project)
     # load the network
@@ -316,7 +316,7 @@ def gather(network: str, allow_missing: bool):
 
     # launch the helper which will try to login
     click.echo("Connecting to Alchemiscale...")
-    client = AlchemiscaleHelper()
+    client = AlchemiscaleHelper.from_settings()
 
     # load the network
     planned_network = FreeEnergyCalculationNetwork.from_file(network)
@@ -396,7 +396,7 @@ def status(network: str, errors: bool, with_traceback: bool, all_networks: bool)
     print_header(console)
 
     # launch the helper which will try to login
-    client = AlchemiscaleHelper()
+    client = AlchemiscaleHelper.from_settings()
     if all_networks:
         # show the results of all tasks in scope, this will print to terminal
         client._client.get_scope_status()
@@ -506,7 +506,7 @@ def restart(network: str, verbose: bool, tasks):
     from asapdiscovery.alchemy.schema.fec import FreeEnergyCalculationNetwork
     from asapdiscovery.alchemy.utils import AlchemiscaleHelper
 
-    client = AlchemiscaleHelper()
+    client = AlchemiscaleHelper.from_settings()
     planned_network = FreeEnergyCalculationNetwork.from_file(network)
 
     tasks = [ScopedKey.from_str(task) for task in tasks]
@@ -541,7 +541,7 @@ def stop(network_key: str):
     console = rich.get_console()
     print_header(console)
 
-    client = AlchemiscaleHelper()
+    client = AlchemiscaleHelper.from_settings()
     cancel_status = console.status(f"Canceling actioned tasks on network {network_key}")
     cancel_status.start()
     canceled_tasks = client.cancel_actioned_tasks(network_key=network_key)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
@@ -38,6 +38,9 @@ class AlchemiscaleSettings(BaseSettings):
     ALCHEMISCALE_KEY: str = Field(
         ..., description="Your personal alchemiscale Key used to login."
     )
+    ALCHEMISCALE_URL: str = Field(
+        "https://api.alchemiscale.org", description="The address of the alchemiscale instance to connect to."
+    )
 
 
 class SolventSettings(_SchemaBase):

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/conftest.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/conftest.py
@@ -48,12 +48,9 @@ def tyk2_reference_data():
 
 
 @pytest.fixture(scope="function")
-def alchemiscale_helper(monkeypatch):
-    monkeypatch.setenv(name="ALCHEMISCALE_ID", value="asap")
-    monkeypatch.setenv(name="ALCHEMISCALE_KEY", value="key")
-
+def alchemiscale_helper():
     # use a fake api url for testing
-    client = AlchemiscaleHelper(api_url="")
+    client = AlchemiscaleHelper(api_url="", key="key", identifier="asap")
 
     # make sure the env variables were picked up
     assert client._client.identifier == "asap"

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -44,20 +44,29 @@ class AlchemiscaleHelper:
     A convenience class to handle alchemiscale submissions restarts and results gathering.
     """
 
-    def __init__(self, api_url: str = "https://api.alchemiscale.org"):
+    def __init__(self, identifier: str, key: str, api_url: str = "https://api.alchemiscale.org"):
         """
-        Create the client which will be used for the rest of the queries
+        Create the client which will be used for the rest of the queries.
+
+        Args:
+            identifier: Your personal alchemiscale ID used to login.
+            key: Your personal alchemiscale KEY used to login.
+            api_url: The URL of the alchemiscale instance to connect to.
         """
         from alchemiscale import AlchemiscaleClient
 
-        # load the settings from the environment
-        settings = AlchemiscaleSettings()
         # connect to the client
         self._client = AlchemiscaleClient(
             api_url=api_url,
-            identifier=settings.ALCHEMISCALE_ID,
-            key=settings.ALCHEMISCALE_KEY,
+            identifier=identifier,
+            key=key,
         )
+
+    @classmethod
+    def from_settings(cls, settings: Optional[AlchemiscaleSettings] = None):
+        if settings is None:
+            settings = AlchemiscaleSettings()
+        return cls(api_url=settings.ALCHEMISCALE_URL, key=settings.ALCHEMISCALE_KEY, identifier=settings.ALCHEMISCALE_ID)
 
     def create_network(
         self, planned_network: FreeEnergyCalculationNetwork, scope: Scope


### PR DESCRIPTION
## Description
This PR allows configuration of the alchemiscale `api_url` via the init or by setting the env variable `ALCHEMISCALE_URL` for the CLI allowing connection to other instances beyond the main deployment.  cc @JenkeScheen 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [ ] Point 1 ...

## Questions
- [ ] Question 1 ..

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
