### PR TITLE
`ASAP-Alchemy` optimize prioritization

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -558,17 +558,17 @@ def prioritize(network_key: str, weight: float):
         f"Changing weight of network {network_key} to {weight}"
     )
     cancel_status.start()
-    canceled_tasks = client.adjust_weight(network_key, weight)
+    new_weight, old_weight = client.adjust_weight(network_key, weight)
     # verify that the weight has been changed
-    if not client.get_network_weight(network_key) == weight:
+    if not new_weight == weight:
         raise ValueError(
             f"Something went wrong during the weight change of network {network_key}:\nAttempted weight change "
-            + f"to {weight} but weight is {client.get_network_weight(network_key)}. "
+            + f"to {weight} but weight is {new_weight}. "
         )
     cancel_status.stop()
 
     message = Padding(
-        f"Adjusted weight to {client.get_network_weight(network_key)} for network {network_key}",
+        f"Adjusted weight from {old_weight} to {new_weight} for network {network_key}",
         (1, 0, 1, 0),
     )
     console.print(message)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -523,6 +523,59 @@ def restart(network: str, verbose: bool, tasks):
 
 @alchemy.command(
     help_priority=6,
+    short_help="Adjust a network's priority. The scheduler picks tasks to action by weight, if this network's weight"
+    + " is set to 0.99 it will be picked in 99% of queries if there is one other network that has a weight of 0.01.",
+)
+@click.option(
+    "-nk",
+    "--network-key",
+    type=click.STRING,
+    help="The network key of the network to be stopped. This can be found by running e.g. `asap-alchemy status -a`.",
+    required=True,
+)
+@click.option(
+    "-w",
+    "--weight",
+    type=click.FloatRange(min=0.0, max=1.0),
+    help="The weight that should be assigned to the network. Network weights can be found by running"
+    + " `asap-alchemy status -a`.",
+    required=True,
+)
+def prioritize(network_key: str, weight: float):
+    """Adjust a network's weight to influence how often its tasks will be actioned compared to other networks."""
+    import rich
+    from asapdiscovery.alchemy.cli.utils import print_header
+    from asapdiscovery.alchemy.utils import AlchemiscaleHelper
+    from rich import pretty
+    from rich.padding import Padding
+
+    pretty.install()
+    console = rich.get_console()
+    print_header(console)
+
+    client = AlchemiscaleHelper.from_settings()
+    cancel_status = console.status(
+        f"Changing weight of network {network_key} to {weight}"
+    )
+    cancel_status.start()
+    canceled_tasks = client.adjust_weight(network_key, weight)
+    # verify that the weight has been changed
+    if not client.get_network_weight(network_key) == weight:
+        raise ValueError(
+            f"Something went wrong during the weight change of network {network_key}:\nAttempted weight change "
+            + f"to {weight} but weight is {client.get_network_weight(network_key)}. "
+        )
+    cancel_status.stop()
+
+    message = Padding(
+        f"Adjusted weight to {client.get_network_weight(network_key)} for network {network_key}",
+        (1, 0, 1, 0),
+    )
+    console.print(message)
+
+
+@alchemy.command(
+    help_priority=7,
     short_help="Stop (i.e. set to 'error') a network's running and waiting tasks.",
 )
 @click.option(
@@ -560,7 +613,7 @@ def stop(network_key: str):
 
 
 @alchemy.command(
-    help_priority=7,
+    help_priority=8,
     short_help="Predict relative and absolute free energies for the set of ligands, using any provided experimental data to shift the results to the relevant energy range.",
 )
 @click.option(

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -569,7 +569,7 @@ def prioritize(network_key: str, weight: float):
     if not new_weight == weight:
         raise ValueError(
             f"Something went wrong during the weight change of network {network_key}:\nAttempted weight change "
-            + f"to {weight} but weight is {new_weight}. "
+            f"to {weight} but weight is {new_weight}."
         )
     adjust_weight_status.stop()
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -560,10 +560,10 @@ def prioritize(network_key: str, weight: float):
     print_header(console)
 
     client = AlchemiscaleHelper.from_settings()
-    cancel_status = console.status(
+    adjust_weight_status = console.status(
         f"Changing weight of network {network_key} to {weight}"
     )
-    cancel_status.start()
+    adjust_weight_status.start()
     new_weight, old_weight = client.adjust_weight(network_key, weight)
     # verify that the weight has been changed
     if not new_weight == weight:
@@ -571,7 +571,7 @@ def prioritize(network_key: str, weight: float):
             f"Something went wrong during the weight change of network {network_key}:\nAttempted weight change "
             + f"to {weight} but weight is {new_weight}. "
         )
-    cancel_status.stop()
+    adjust_weight_status.stop()
 
     message = Padding(
         f"Adjusted weight from {old_weight} to {new_weight} for network {network_key}",

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -436,8 +436,14 @@ def status(network: str, errors: bool, with_traceback: bool, all_networks: bool)
             networks=running_networks
         )
         network_weights = client._client.get_networks_weight(networks=running_networks)
-        for key, network_status, actioned_tasks, network_weight in zip(
+
+        # sort the networks by weight so that we get the ones with highest weights showing first in the table
+        networks_data = zip(
             running_networks, networks_status, networks_actioned_tasks, network_weights
+        )
+
+        for key, network_status, actioned_tasks, network_weight in sorted(
+            networks_data, key=lambda element: element[-1], reverse=True
         ):
             if (
                 "running" in network_status or "waiting" in network_status

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -219,16 +219,11 @@ def plan(
     help="The name of the project in alchemiscale the network should be submitted to.",
     required=True,
 )
-@click.option(
-    "-pr",
-    "--prioritize",
-    type=click.BOOL,
-    default=None,
-    help="Whether to prioritize the submitted network to have the highest priority of all currently running/waiting networks, or to de-prioritize it instead. Defaults to 0.5 which is the `alchemiscale` default network priority.",
-    show_default=True,
-)
 def submit(
-    network: str, organization: str, campaign: str, project: str, prioritize: bool
+    network: str,
+    organization: str,
+    campaign: str,
+    project: str,
 ):
     """
     Submit a local FreeEnergyCalculationNetwork to alchemiscale using the provided scope details. The network object
@@ -269,9 +264,7 @@ def submit(
     submitted_network.to_file(network)
     # now action the tasks
     click.echo("Creating and actioning FEC tasks on Alchemiscale...")
-    task_ids = client.action_network(
-        planned_network=submitted_network, prioritize=prioritize
-    )
+    task_ids = client.action_network(planned_network=submitted_network)
     # check that all tasks were created
     missing_tasks = sum([1 for task in task_ids if task is None])
     total_tasks = len(task_ids)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
@@ -63,18 +63,10 @@ def test_network_status(monkeypatch, tyk2_fec_network, alchemiscale_helper):
     assert status == {"complete": 1}
 
 
-@pytest.mark.parametrize(
-    "priority, expected_weight",
-    [
-        pytest.param(None, 0.5, id="None"),
-        pytest.param(True, 0.51, id="True"),
-        pytest.param(False, 0.49, id="False"),
-    ],
-)
 def test_action_tasks(
-    monkeypatch, tyk2_fec_network, alchemiscale_helper, priority, expected_weight
+    monkeypatch, tyk2_fec_network, alchemiscale_helper
 ):
-    """Make sure the helper can action tasks on alchemiscale with the correct priority"""
+    """Make sure the helper can action tasks on alchemiscale."""
 
     client = alchemiscale_helper
 
@@ -105,23 +97,17 @@ def test_action_tasks(
             for _ in range(count)
         ]
 
-    def action_tasks(tasks, network, weight):
+    def action_tasks(tasks, network):
         "mock actioning tasks"
         # make sure we get the correct key for the submission
         assert network == network_key
-        # make sure we get the expected weight for this priority
-        assert weight == expected_weight
         return tasks
-
-    def actioned_weights():
-        return [0.5]
 
     monkeypatch.setattr(
         client._client, "get_network_transformations", get_network_transformations
     )
     monkeypatch.setattr(client._client, "create_tasks", create_tasks)
     monkeypatch.setattr(client._client, "action_tasks", action_tasks)
-    monkeypatch.setattr(client, "get_actioned_weights", actioned_weights)
 
     tasks = client.action_network(planned_network=result_network)
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
@@ -123,7 +123,7 @@ def test_action_tasks(
     monkeypatch.setattr(client._client, "action_tasks", action_tasks)
     monkeypatch.setattr(client, "get_actioned_weights", actioned_weights)
 
-    tasks = client.action_network(planned_network=result_network, prioritize=priority)
+    tasks = client.action_network(planned_network=result_network)
 
     assert len(tasks) == (result_network.n_repeats + 1) * len(alchem_network.edges)
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -326,6 +326,25 @@ class AlchemiscaleHelper:
             canceled_tasks = []
         return canceled_tasks
 
+    def adjust_weight(self, network_key: ScopedKey, weight: float) -> float:
+        """
+        Adjust the weight of a network to influence how often its tasks get actioned
+        by the alchemiscale scheduler.
+
+        Args:
+            network_key: The alchemiscale network key that should have its weight adjusted.
+            weight: The weight (a float between 0.0 and 1.0) that should be assigned.
+
+        Returns:
+            The new weight that is assigned to the network.
+            The weight that was previously assigned to the network.
+        """
+        old_weight = self._client.get_network_weight(network_key)
+
+        self._client.set_network_weight(network_key, weight)
+
+        return self._client.get_network_weight(network_key), old_weight
+
 
 def select_reference_for_compounds(
     ligands: list["Ligand"],

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -134,15 +134,12 @@ class AlchemiscaleHelper:
     def action_network(
         self,
         planned_network: FreeEnergyCalculationNetwork,
-        prioritize: Optional[bool] = None,
     ) -> list[Optional[ScopedKey]]:
         """
         For the given network which is already stored on alchemiscale create and action tasks.
 
         Args:
             planned_network: The network which should action tasks for.
-            prioritize: Whether the network should be set to `high` or `low` priority. If undefined,
-                defaults to standard priority (0.5).
 
         Returns:
             A list of actioned tasks for this network.
@@ -156,17 +153,8 @@ class AlchemiscaleHelper:
                 self._client.create_tasks(tf_sk, count=planned_network.n_repeats + 1)
             )
 
-        # set the network weight based on the found network weights that are currently
-        # running while making sure the weight doesn't fall outside 0.1-1 as 0.0 turns of compute.
-        if prioritize is True:
-            weight = np.clip(max(self.get_actioned_weights()) + 0.01, 0.1, 1.0)
-        elif prioritize is False:
-            weight = np.clip(min(self.get_actioned_weights()) - 0.01, 0.1, 1.0)
-        else:
-            weight = 0.5
-
         # now action the tasks to ensure they are picked up by compute.
-        actioned_tasks = self._client.action_tasks(tasks, network_key, weight=weight)
+        actioned_tasks = self._client.action_tasks(tasks, network_key, weight=0.5)
         return actioned_tasks
 
     def network_status(

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -154,7 +154,7 @@ class AlchemiscaleHelper:
             )
 
         # now action the tasks to ensure they are picked up by compute.
-        actioned_tasks = self._client.action_tasks(tasks, network_key, weight=0.5)
+        actioned_tasks = self._client.action_tasks(tasks, network_key)
         return actioned_tasks
 
     def network_status(

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -328,7 +328,7 @@ class AlchemiscaleHelper:
 
     def adjust_weight(
         self, network_key: ScopedKey, weight: float
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         """
         Adjust the weight of a network to influence how often its tasks get actioned
         by the alchemiscale scheduler.

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy as np
 from alchemiscale import Scope, ScopedKey

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -326,7 +326,7 @@ class AlchemiscaleHelper:
             canceled_tasks = []
         return canceled_tasks
 
-    def adjust_weight(self, network_key: ScopedKey, weight: float) -> float:
+    def adjust_weight(self, network_key: ScopedKey, weight: float) -> Tuple[float, float]:
         """
         Adjust the weight of a network to influence how often its tasks get actioned
         by the alchemiscale scheduler.

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from alchemiscale import Scope, ScopedKey

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -326,7 +326,9 @@ class AlchemiscaleHelper:
             canceled_tasks = []
         return canceled_tasks
 
-    def adjust_weight(self, network_key: ScopedKey, weight: float) -> Tuple[float, float]:
+    def adjust_weight(
+        self, network_key: ScopedKey, weight: float
+    ) -> Tuple[float, float]:
         """
         Adjust the weight of a network to influence how often its tasks get actioned
         by the alchemiscale scheduler.


### PR DESCRIPTION
solves https://github.com/asapdiscovery/asapdiscovery/issues/973

Instead of specifying during `submit`, there's now a separate CLI endpoint for adjusting network weights. users will be able to adjust network weights manually with minimal effort. We may need to revisit once we get _many_ networks running at the same time up to the point where manual adjustment is impractical, but with `alchemiscale`'s random actioning (influenced by weights) that may be complicated. 


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
