### PR TITLE
Add option to zoom GIFVisualizer into binding site

### DIFF
--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
@@ -82,7 +82,9 @@ class GIFVisualizer(VisualizerBase):
         False, description="Whether to only generate static views"
     )
     zoom_view: bool = Field(
-        False, description="Whether to zoom into the binding site on final output visualization")
+        False,
+        description="Whether to zoom into the binding site on final output visualization",
+    )
     start: PositiveInt = Field(
         1800,
         description="Start frame - if not defined, will default to last 10% of default trajectory settings",
@@ -283,6 +285,7 @@ class GIFVisualizer(VisualizerBase):
 
         # Process the trajectory in a temporary directory
         from pygifsicle import gifsicle
+
         if zoom_view:
             p.cmd.zoom("binding_site")
         # now make the movie.

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
@@ -54,6 +54,8 @@ class GIFVisualizer(VisualizerBase):
         Whether to generate contact maps
     static_view_only : bool
         Whether to only generate static PSE for the trajectory
+    zoom_view : bool
+        Whether to zoom into the binding site on final output visualization
     start : PositiveInt
         Start frame - if not defined, will default to last 10% of default trajectory settings
     stop : int
@@ -79,6 +81,8 @@ class GIFVisualizer(VisualizerBase):
     static_view_only: bool = Field(
         False, description="Whether to only generate static views"
     )
+    zoom_view: bool = Field(
+        False, description="Whether to zoom into the binding site on final output visualization")
     start: PositiveInt = Field(
         1800,
         description="Start frame - if not defined, will default to last 10% of default trajectory settings",
@@ -117,6 +121,7 @@ class GIFVisualizer(VisualizerBase):
         smooth: int,
         contacts: bool,
         frames_per_ns: int,
+        zoom_view: bool,
         outpath: Optional[Path] = None,
         out_dir: Optional[Path] = None,
     ):
@@ -278,7 +283,8 @@ class GIFVisualizer(VisualizerBase):
 
         # Process the trajectory in a temporary directory
         from pygifsicle import gifsicle
-
+        if zoom_view:
+            p.cmd.zoom("binding_site")
         # now make the movie.
         p.cmd.set(
             "ray_trace_frames", 0
@@ -372,6 +378,7 @@ class GIFVisualizer(VisualizerBase):
                     smooth=self.smooth,
                     contacts=self.contacts,
                     frames_per_ns=self.frames_per_ns,
+                    zoom_view=self.zoom_view,
                     out_dir=self.output_dir,
                 )
                 row = {}
@@ -441,6 +448,7 @@ class GIFVisualizer(VisualizerBase):
                     smooth=self.smooth,
                     contacts=self.contacts,
                     frames_per_ns=self.frames_per_ns,
+                    zoom_view=self.zoom_view,
                     out_dir=self.output_dir,
                 )
                 row = {}


### PR DESCRIPTION
## Description
The current implementation of `GIFVisualizer.visualize()` sometimes have issues with centering the final view of the output (which is a problem for the .gif file). I added the `zoom_view` parameter to `GIFVisualizer`, which if True, will center the .gif view to the binding site. 

I placed the centering command right before generating the _Session 6_ PyMOL output, so it only affect this and the .gif file. I could move it so it centers other outputs, but don't think it's important for a PyMOL file to be initially centered.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Review.

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
