### PR TITLE
Update mtenn pin for upcoming breaking release.

### DIFF
--- a/devtools/conda-envs/asapdiscovery-macOS-12.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-12.yml
@@ -64,7 +64,7 @@ dependencies:
   - dgl <=2.0.0
   - dgllife
   - pooch
-  - mtenn >=0.5.1,<=0.5.2
+  - mtenn =0.5.2
   - wandb
 
   # md

--- a/devtools/conda-envs/asapdiscovery-macOS-12.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-12.yml
@@ -64,7 +64,7 @@ dependencies:
   - dgl <=2.0.0
   - dgllife
   - pooch
-  - mtenn >=0.5.1
+  - mtenn >=0.5.1,<=0.5.2
   - wandb
 
   # md

--- a/devtools/conda-envs/asapdiscovery-macOS-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-latest.yml
@@ -63,7 +63,7 @@ dependencies:
   - dgl <=2.0.0
   - dgllife
   - pooch
-  - mtenn >=0.5.1
+  - mtenn >=0.5.1,<=0.5.2
   - wandb
 
   # md

--- a/devtools/conda-envs/asapdiscovery-macOS-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-latest.yml
@@ -63,7 +63,7 @@ dependencies:
   - dgl <=2.0.0
   - dgllife
   - pooch
-  - mtenn >=0.5.1,<=0.5.2
+  - mtenn =0.5.2
   - wandb
 
   # md

--- a/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
@@ -64,7 +64,7 @@ dependencies:
   - dgl <=2.0.0
   - dgllife
   - pooch
-  - mtenn >=0.5.1,<=0.5.2
+  - mtenn =0.5.2
   - wandb
 
   # md

--- a/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
@@ -64,7 +64,7 @@ dependencies:
   - dgl <=2.0.0
   - dgllife
   - pooch
-  - mtenn >=0.5.1
+  - mtenn >=0.5.1,<=0.5.2
   - wandb
 
   # md


### PR DESCRIPTION
Going to cut an `mtenn` release soon that will break the current code, so pin to <= current version. Code is being updated to work with the new `mtenn` version in #1081.