### PR TITLE
Improve MCS performance

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/operators/selectors/mcs_selector.py
+++ b/asapdiscovery-data/asapdiscovery/data/operators/selectors/mcs_selector.py
@@ -242,30 +242,3 @@ class MCSSelector(SelectorBase):
 
     def provenance(self):
         return {"selector": self.dict(), "oechem": oechem.OEChemGetVersion()}
-
-
-
-def _mcs_inner_row(mcss, complexes, n_select, ligand, pair_cls):
-    """
-    Do one dimension of the NxM MCS search, ie for a single ligand
-    check all complexes for MCS overlap.
-    """
-    for complex in complexes:
-        complex_mol = complex.ligand.to_oemol()
-        # MCS search
-        sort_args = []
-        try:
-            mcs = next(iter(mcss.Match(complex_mol, True)))
-            sort_args.append((mcs.NumBonds(), mcs.NumAtoms()))
-        except StopIteration:
-            sort_args.append((0, 0))
-    
-    sort_args = np.asarray(sort_args)
-    sort_idx = np.lexsort(-sort_args.T)
-    complexes_sorted = np.asarray(complexes)[sort_idx]
-
-    pairs = []
-    for i in range(n_select):
-        pairs.append(pair_cls(ligand=ligand, complex=complexes_sorted[i]))
-    return pairs
-    

--- a/asapdiscovery-data/asapdiscovery/data/operators/selectors/mcs_selector.py
+++ b/asapdiscovery-data/asapdiscovery/data/operators/selectors/mcs_selector.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import ClassVar, Union
 
 import numpy as np
@@ -9,7 +10,6 @@ from asapdiscovery.data.schema.ligand import Ligand
 from asapdiscovery.data.schema.pairs import CompoundStructurePair
 from asapdiscovery.docking.docking import DockingInputPair  # TODO: move to backend
 from pydantic import Field
-import warnings
 
 logger = logging.getLogger(__name__)
 

--- a/asapdiscovery-data/asapdiscovery/data/operators/selectors/mcs_selector.py
+++ b/asapdiscovery-data/asapdiscovery/data/operators/selectors/mcs_selector.py
@@ -214,14 +214,7 @@ class MCSSelector(SelectorBase):
                 pairs.append(pair_cls(ligand=ligand, complex=complexes[0]))
                 continue
 
-            pattern_query = oechem.OEQMol(ligand.to_oemol())
-            pattern_query.BuildExpressions(atomexpr, bondexpr)
-            if self.approximate:
-                mcs_stype = oechem.OEMCSType_Approximate
-            else:
-                mcs_stype = oechem.OEMCSType_Exhaustive
-            mcss = oechem.OEMCSSearch(pattern_query, True, mcs_stype)
-            mcss.SetMCSFunc(oechem.OEMCSMaxAtomsCompleteCycles())
+
 
 
             # due to memory issues in constructing lots of MCS search objects in parallel in outer loop
@@ -231,7 +224,9 @@ class MCSSelector(SelectorBase):
 
                 pairs.append(
                     delayed(_mcs_inner_row)(
-                        mcss=mcss,
+                        atomexpr=atomexpr,
+                        bondexpr=bondexpr,
+                        approximate=self.approximate,
                         complexes=complexes,
                         n_select=n_select,
                         ligand=ligand,
@@ -243,7 +238,9 @@ class MCSSelector(SelectorBase):
 
                 pairs.extend(
                     _mcs_inner_row(
-                        mcss=mcss,
+                        atomexpr=atomexpr,
+                        bondexpr=bondexpr,
+                        approximate=self.approximate,
                         complexes=complexes,
                         n_select=n_select,
                         ligand=ligand,
@@ -263,11 +260,20 @@ class MCSSelector(SelectorBase):
 
 
 
-def _mcs_inner_row(mcss, complexes, n_select, ligand, pair_cls):
+def _mcs_inner_row(atomexpr, bondexpr, approximate, complexes, n_select, ligand, pair_cls):
     """
     Do one dimension of the NxM MCS search, ie for a single ligand
     check all complexes for MCS overlap.
     """
+
+    pattern_query = oechem.OEQMol(ligand.to_oemol())
+    pattern_query.BuildExpressions(atomexpr, bondexpr)
+    if approximate:
+        mcs_stype = oechem.OEMCSType_Approximate
+    else:
+        mcs_stype = oechem.OEMCSType_Exhaustive
+    mcss = oechem.OEMCSSearch(pattern_query, True, mcs_stype)
+    mcss.SetMCSFunc(oechem.OEMCSMaxAtomsCompleteCycles())
     for complex in complexes:
         complex_mol = complex.ligand.to_oemol()
         # MCS search

--- a/asapdiscovery-data/asapdiscovery/data/operators/selectors/mcs_selector.py
+++ b/asapdiscovery-data/asapdiscovery/data/operators/selectors/mcs_selector.py
@@ -9,6 +9,7 @@ from asapdiscovery.data.schema.ligand import Ligand
 from asapdiscovery.data.schema.pairs import CompoundStructurePair
 from asapdiscovery.docking.docking import DockingInputPair  # TODO: move to backend
 from pydantic import Field
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +155,12 @@ class MCSSelector(SelectorBase):
             raise ValueError("All complexes must be of the same type")
 
         pair_cls = self._pair_type_from_complex(complexes[0])
+
+        if self.approximate:
+            warnings.warn(
+                "Approximate MCS search is not guaranteed to find the maximum common substructure, see: https://docs.eyesopen.com/toolkits/python/oechemtk/patternmatch.html ",
+                UserWarning,
+            )
 
         # clip n_select if it is larger than length of complexes to search from
         n_select = min(n_select, len(complexes))

--- a/asapdiscovery-data/asapdiscovery/data/operators/selectors/mcs_selector.py
+++ b/asapdiscovery-data/asapdiscovery/data/operators/selectors/mcs_selector.py
@@ -7,10 +7,6 @@ from asapdiscovery.data.operators.selectors.selector import SelectorBase
 from asapdiscovery.data.schema.complex import Complex, ComplexBase, PreppedComplex
 from asapdiscovery.data.schema.ligand import Ligand
 from asapdiscovery.data.schema.pairs import CompoundStructurePair
-from asapdiscovery.data.util.dask_utils import (
-    FailureMode,
-    actualise_dask_delayed_iterable,
-)
 from asapdiscovery.docking.docking import DockingInputPair  # TODO: move to backend
 from pydantic import Field
 

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_selectors.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_selectors.py
@@ -44,8 +44,10 @@ def test_pairwise_selector_prepped(ligands_from_complexes, prepped_complexes, us
     assert len(pairs) == 8
 
 
-def test_mcs_selector(ligands_from_complexes, complexes):
-    selector = MCSSelector()
+@pytest.mark.parametrize("approximate", [True, False])
+@pytest.mark.parametrize("structure_based", [True, False])
+def test_mcs_selector(ligands_from_complexes, complexes, approximate, structure_based):
+    selector = MCSSelector(approximate=approximate, structure_based=structure_based)
     pairs = selector.select(ligands_from_complexes, complexes, n_select=1)
     # should be 4 pairs
     assert len(pairs) == 4

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/large_scale_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/large_scale_docking.py
@@ -246,7 +246,7 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
     # which are quite large themselves, is only effective for large numbers of ligands and small numbers of complexes
     # TODO: fix, see issue 560
     logger.info("Selecting pairs for docking based on MCS")
-    selector = MCSSelector()
+    selector = MCSSelector(approximate=True)
     pairs = selector.select(
         query_ligands,
         prepped_complexes,

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/small_scale_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/small_scale_docking.py
@@ -266,7 +266,7 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
     # using dask here is too memory intensive as each worker needs a copy of all the complexes in memory
     # which are quite large themselves, is only effective for large numbers of ligands and small numbers of complexes
     logger.info("Selecting pairs for docking based on MCS")
-    selector = MCSSelector()
+    selector = MCSSelector(approximate=True) # use faster approximate matcher
     pairs = selector.select(
         query_ligands,
         prepped_complexes,


### PR DESCRIPTION
Improves the MCS performance by allowing the use of a faster approximate method. 

We couldn't multiprocess or use dask due to limitations outlined in #560. 

We may need to investigate RDKit based MCS searching for a parallel component, but may run into the same issue there. 


## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
