### PR TITLE
Add minimize_only option to VanillaMDSimulator

### DIFF
--- a/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
@@ -176,7 +176,8 @@ class VanillaMDSimulator(SimulatorBase):
     )
 
     minimize_only: bool = Field(
-        False, description="Whether to carry out a single minimization step.",
+        False,
+        description="Whether to carry out a single minimization step.",
     )
 
     @validator("rmsd_restraint_type")

--- a/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
@@ -175,6 +175,10 @@ class VanillaMDSimulator(SimulatorBase):
         description="The OpenFF small molecule force field which should be used for the ligand.",
     )
 
+    minimize_only: bool = Field(
+        False, description="Whether to carry out a single minimization step.",
+    )
+
     @validator("rmsd_restraint_type")
     @classmethod
     def check_restraint_type(cls, v):
@@ -382,6 +386,16 @@ class VanillaMDSimulator(SimulatorBase):
         simulation, context = self.setup_simulation(
             modeller, system, output_indices, output_topology, outpath, _platform
         )
+        if self.minimize_only:
+            sim_result = SimulationResult(
+                input_docking_result=input_docking_result,
+                traj_path="",
+                minimized_pdb_path=outpath / "minimized.pdb",
+                final_pdb_path="",
+                success=True,
+            )
+            return sim_result
+
         logger.info("Setup simulation")
         simulation = self.equilibrate(simulation)
         logger.info("Equilibrated")


### PR DESCRIPTION
## Description
Adding option to do minimization to docking result without having to run equilibration/production. Fixes https://github.com/asapdiscovery/asapdiscovery/issues/1154 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Add option
- [ ] Testing?

## Questions
- [ ] Question 1 ..

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
