### PR TITLE
Add custom glob to structure dir

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/readers/structure_dir.py
+++ b/asapdiscovery-data/asapdiscovery/data/readers/structure_dir.py
@@ -26,6 +26,10 @@ class StructureDirFactory(BaseModel):
     parent_dir: Path = Field(
         description="Directory containing structure files as PDBs."
     )
+    glob: str = Field(
+        default="*.pdb",
+        description="Regex pattern for matching PDB files in the directory.",
+    )
 
     @validator("parent_dir")
     def parent_dir_exists(cls, v):
@@ -59,7 +63,7 @@ class StructureDirFactory(BaseModel):
         List[Complex]
             List of Complex objects.
         """
-        pdb_files = list(self.parent_dir.rglob("*.pdb"))
+        pdb_files = list(self.parent_dir.glob(self.glob))
         # check all filenames are unique
         pdb_stems = [pdb_file.stem for pdb_file in pdb_files]
         unique = False

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_structure_dir_factory_schema.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_structure_dir_factory_schema.py
@@ -23,3 +23,10 @@ def test_structure_dir(use_dask, structure_dir):
     factory = StructureDirFactory.from_dir(struct_dir)
     complexes = factory.load(use_dask=use_dask)
     assert len(complexes) == 2
+
+def test_custom_glob(structure_dir):
+    struct_dir, _ = structure_dir
+    factory = StructureDirFactory.from_dir(struct_dir)
+    factory.glob = "*x1002*.pdb"
+    complexes = factory.load()
+    assert len(complexes) == 1

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_structure_dir_factory_schema.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_structure_dir_factory_schema.py
@@ -24,6 +24,7 @@ def test_structure_dir(use_dask, structure_dir):
     complexes = factory.load(use_dask=use_dask)
     assert len(complexes) == 2
 
+
 def test_custom_glob(structure_dir):
     struct_dir, _ = structure_dir
     factory = StructureDirFactory.from_dir(struct_dir)


### PR DESCRIPTION
## Description
Allows specifying a custom glob for `StructureDirFactory`


## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
