### PR TITLE
[HOTFIX] Fix edge case on clashing tag names in postera

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/services/postera/molecule_set.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/molecule_set.py
@@ -1,6 +1,6 @@
 import logging
-from typing import Dict, Optional, Tuple, Union  # noqa: F401
 import warnings
+from typing import Dict, Optional, Tuple, Union  # noqa: F401
 
 import pandas as pd
 from asapdiscovery.data.services.web_utils import _BaseWebAPI
@@ -295,22 +295,23 @@ class MoleculeSetAPI(_BaseWebAPI):
         if return_as == "list":
             return results
         elif return_as == "dataframe":
-            
-            response_data = [ ]
+
+            response_data = []
             for result in results:
-                data =                    {
-                        MoleculeSetKeys.smiles.value: result[MoleculeSetKeys.smiles.value],
-                        MoleculeSetKeys.id.value: result[MoleculeSetKeys.id.value],
-                    }
+                data = {
+                    MoleculeSetKeys.smiles.value: result[MoleculeSetKeys.smiles.value],
+                    MoleculeSetKeys.id.value: result[MoleculeSetKeys.id.value],
+                }
                 # rare case where customData has the same key name as a reserved key like id or smiles
                 for key, value in result["customData"].items():
                     if key in MoleculeSetKeys.get_values():
-                        warnings.warn(f"Custom data key name {key} is the same as a reserved key name, skipping..")
+                        warnings.warn(
+                            f"Custom data key name {key} is the same as a reserved key name, skipping.."
+                        )
                     else:
                         data[key] = value
 
                 response_data.append(data)
-            
 
             return pd.DataFrame(response_data)
 

--- a/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
@@ -55,8 +55,8 @@ class PosteraFactory(BaseModel):
 
                 ligand.tags = tags
                 ligands.append(ligand)
-            except:  # noqa: E722
-                warnings.warn(f"Failed to create ligand from smiles: {smiles}")
+            except Exception as e:  # noqa: E722
+                warnings.warn(f"Failed to create ligand from smiles: {smiles}, error is: {e}")
         return ligands
 
     def pull(self) -> list[Ligand]:

--- a/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
@@ -54,17 +54,18 @@ class PosteraFactory(BaseModel):
                             f"Custom column name {custom_col} is already a field in Ligand, skipping.."
                         )
                         continue
-                    
+
                     if mol[custom_col] is None:
                         mol[custom_col] = ""
-                    
-                    tags[custom_col] = mol[custom_col]
 
+                    tags[custom_col] = mol[custom_col]
 
                 ligand.tags = tags
                 ligands.append(ligand)
             except Exception as e:  # noqa: E722
-                warnings.warn(f"Failed to create ligand from smiles: {smiles}, error is: {e}")
+                warnings.warn(
+                    f"Failed to create ligand from smiles: {smiles}, error is: {e}"
+                )
         return ligands
 
     def pull(self) -> list[Ligand]:

--- a/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
@@ -49,9 +49,17 @@ class PosteraFactory(BaseModel):
                 # now append custom data to the Ligand's tags, if there is any
                 tags = {}
                 for custom_col in custom_data_columns:
+                    if custom_col in Ligand.__fields__.keys():
+                        warnings.warn(
+                            f"Custom column name {custom_col} is already a field in Ligand, skipping.."
+                        )
+                        continue
+                    
                     if mol[custom_col] is None:
                         mol[custom_col] = ""
+                    
                     tags[custom_col] = mol[custom_col]
+
 
                 ligand.tags = tags
                 ligands.append(ligand)


### PR DESCRIPTION
Sometimes people put reserved keynames like `id` or `smiles` in customdata for a molecule, avoid this. 

## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
