### PR TITLE
update default to much faster box shape

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
@@ -775,7 +775,7 @@ def create_absolute_report(dataframe: pd.DataFrame) -> panel.Column:
     plotting_df = dataframe.dropna(axis=0, inplace=False)
     plotting_df.reset_index(inplace=True)
     # only make the plot if we have exp data and more than one point
-    if len(plotting_df) > 1 and "DG (kcal/mol) (EXPT)" in plotting_df.columns:
+    if len(plotting_df) > 2 and "DG (kcal/mol) (EXPT)" in plotting_df.columns:
 
         # add pIC50 columns beside DG
         add_pic50_columns(plotting_df)
@@ -888,7 +888,7 @@ def create_relative_report(dataframe: pd.DataFrame) -> panel.Column:
     number_format = bokeh.models.widgets.tables.NumberFormatter(format="0.0000")
     # only plot the graph if we have exp data and more than a single point
     make_plots_stats = (
-        len(plotting_df) > 1 and "DDG (kcal/mol) (EXPT)" in plotting_df.columns
+        len(plotting_df) > 2 and "DDG (kcal/mol) (EXPT)" in plotting_df.columns
     )
 
     if make_plots_stats:

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
@@ -223,7 +223,7 @@ class _FreeEnergyBase(_SchemaBase):
         description="The settings for thermodynamic parameters.",
     )
     solvation_settings: OpenMMSolvationSettings = Field(
-        OpenMMSolvationSettings(),
+        OpenMMSolvationSettings(box_shape="dodecahedron"),
         description="Settings controlling how the systems should be solvated using OpenMM.",
     )
     alchemical_settings: AlchemicalSettings = Field(


### PR DESCRIPTION
This results in a 12-faced solvation box (fewer waters to simulate, i.e. faster production runs) and default filling to settings:
```
  "solvation_settings": {
    "solvent_model": "tip3p",
    "solvent_padding": {
      "magnitude": 1.2,
      "unit": "nanometer",
      ":is_custom:": true,
      "pint_unit_registry": "openff_units"
    },
    "box_shape": "dodecahedron",
    "number_of_solvent_molecules": null,
    "box_vectors": null,
    "box_size": null
  },
```

See OpenFE's docstring for this shape: https://github.com/OpenFreeEnergy/openfe/blob/35b5f12d2e948cc4c637177dd920f276e7f94259/openfe/protocols/openmm_utils/omm_settings.py#L121-L128

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
