### PR TITLE
Pin mtenn version for pydantic 2

### DIFF
--- a/devtools/conda-envs/asapdiscovery-macOS-12.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-12.yml
@@ -64,7 +64,7 @@ dependencies:
   - dgl <=2.0.0
   - dgllife
   - pooch
-  - mtenn >=0.6.1
+  - mtenn =0.6.2
   - wandb
 
   # md

--- a/devtools/conda-envs/asapdiscovery-macOS-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-latest.yml
@@ -62,7 +62,7 @@ dependencies:
   - dgl <=2.0.0
   - dgllife
   - pooch
-  - mtenn >=0.6.1
+  - mtenn =0.6.2
   - wandb
 
   # md

--- a/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
@@ -63,7 +63,7 @@ dependencies:
   - dgl <=2.0.0
   - dgllife
   - pooch
-  - mtenn >=0.6.1
+  - mtenn =0.6.2
   - wandb
 
   # md


### PR DESCRIPTION
`mtenn` was recently updated to pydantic 2, so pin the pydantic 1 version until `asapdiscovery` is updated. Closes #1244.