### PR TITLE
`alchemy` add hard stop functionality

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -760,7 +760,12 @@ def prioritize(network_key: str, weight: float):
     help="The network key of the network to be stopped. This can be found by running e.g. `asap-alchemy status -a`.",
     required=True,
 )
-def stop(network_key: str):
+@click.option(
+    "--hard",
+    is_flag=True,
+    help="If used, all waiting and running tasks will be deleted instead of un-actioned. Warning: these tasks will not be retrievable/re-runnable.",
+)
+def stop(network_key: str, hard: bool = False):
     """Stop (i.e. set to 'error') a network's running and waiting tasks."""
     import rich
     from asapdiscovery.alchemy.cli.utils import print_header
@@ -773,9 +778,13 @@ def stop(network_key: str):
     print_header(console)
 
     client = AlchemiscaleHelper.from_settings()
+    if hard:
+        console.print(
+            f"Warning: deleting all running/waiting tasks on network {network_key}. These will not be retrievable/re-runnable!"
+        )
     cancel_status = console.status(f"Canceling actioned tasks on network {network_key}")
     cancel_status.start()
-    canceled_tasks = client.cancel_actioned_tasks(network_key=network_key)
+    canceled_tasks = client.cancel_actioned_tasks(network_key=network_key, hard=hard)
     # check how many were canceled as some maybe None if not found
     total_tasks = len([task for task in canceled_tasks if task is not None])
     cancel_status.stop()

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -332,7 +332,9 @@ class AlchemiscaleHelper:
                     error_data.append(failure)
         return error_data
 
-    def cancel_actioned_tasks(self, network_key: ScopedKey) -> list[ScopedKey]:
+    def cancel_actioned_tasks(
+        self, network_key: ScopedKey, hard: bool
+    ) -> list[ScopedKey]:
         """
         Cancel all currently actioned tasks on a network to stop all future compute.
 
@@ -342,17 +344,36 @@ class AlchemiscaleHelper:
 
         Args:
             network_key: The alchemiscale network key who's actioned tasks should be canceled.
+            hard: If true, all running/waiting tasks will be deleted. Warning: these are not retrievable/re-runnable.
 
         Returns:
             A list of the ScopedKeys of all canceled tasks.
         """
-        actioned_tasks = self._client.get_network_actioned_tasks(network=network_key)
-        if actioned_tasks:
-            canceled_tasks = self._client.cancel_tasks(
-                tasks=actioned_tasks, network=network_key
+        if hard:
+            running_tasks = self._client.get_network_tasks(
+                network=network_key, status="running"
             )
+            waiting_tasks = self._client.get_network_tasks(
+                network=network_key, status="waiting"
+            )
+            tasks_to_delete = running_tasks + waiting_tasks
+            if tasks_to_delete:
+                canceled_tasks = self._client.set_tasks_status(
+                    running_tasks, status="deleted"
+                )
+            else:
+                canceled_tasks = []
         else:
-            canceled_tasks = []
+            actioned_tasks = self._client.get_network_actioned_tasks(
+                network=network_key
+            )
+            if actioned_tasks:
+                canceled_tasks = self._client.cancel_tasks(
+                    tasks=actioned_tasks, network=network_key
+                )
+            else:
+                canceled_tasks = []
+
         return canceled_tasks
 
     def adjust_weight(


### PR DESCRIPTION
Solves https://github.com/asapdiscovery/asapdiscovery/issues/1196. This will allow us to _actually_ stop networks that have been submitted e.g. accidentally. Up to this PR, any running tasks would have 'escaped' cancelling because the `stop` method only set `waiting` to non-actioned. With this PR we hard a hard stop extension to the CLI so that we can prevent unnecessary compute.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
