### PR TITLE
fix occasional crashes in solvent phase

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
@@ -88,7 +88,7 @@ class AdaptiveSettings(_SchemaBase):
         description="The solvent padding (in nm) to use for the complex phase of each edge.",
     )
     solvent_padding_solvated: FloatQuantity["nanometer"] = Field(  # noqa: F821
-        1.2 * OFFUnit.nanometer,
+        1.5 * OFFUnit.nanometer,
         description="The solvent padding (in nm) to use for the solvated phase of each edge.",
     )
 


### PR DESCRIPTION
1.2nm padding sometimes crashes in solvent phase - just switching back to 1.5 because solvent phase is fast anyway.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
