### PR TITLE
Changes to enable use of alchemiscale v0.6.x

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/interfaces.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/interfaces.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
 
 class AlchemiscaleSettings(BaseSettings):

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/_alchemiscale.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/_alchemiscale.py
@@ -1,0 +1,233 @@
+"""
+:mod:`alchemiscale.models` --- common data models
+=================================================
+
+"""
+
+from typing import Optional, Union
+from pydantic import BaseModel, Field, validator, root_validator
+from gufe.tokenization import GufeKey
+from re import fullmatch
+import unicodedata
+import string
+
+
+class Scope(BaseModel):
+    org: Optional[str] = None
+    campaign: Optional[str] = None
+    project: Optional[str] = None
+
+    def __init__(self, org=None, campaign=None, project=None):
+        # we add this to allow for arg-based creation, not just keyword-based
+        super().__init__(org=org, campaign=campaign, project=project)
+
+    def __str__(self):
+        triple = (
+            i if i is not None else "*" for i in (self.org, self.campaign, self.project)
+        )
+        return "-".join(triple)
+
+    def __lt__(self, other):
+        return str(self) < str(other)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        return str(self) == str(other)
+
+    class Config:
+        frozen = True
+
+    @staticmethod
+    def _validate_component(v, component):
+        """
+        Use regex to check that the component:
+        - contains only alphanumeric or underscore characters, or is just a single asterisk
+        - does not start with an underscore or number
+        """
+
+        # we require that there is a full match, so that the string is not
+        # allowed to contain any other characters.
+        if v is not None and not fullmatch(r"^[a-zA-Z][a-zA-Z0-9_]*|\*$", v):
+            raise InvalidScopeError(
+                f"'{component}' must either start with an alphabetical and contain "
+                "only alphanumeric or underscore ('_') thereafter "
+                "OR must be a single asterisk ('*')"
+            )
+
+        if v == "*":
+            # if we're given an asterisk, cast this to `None` instead for
+            # consistency
+            v = None
+
+        return v
+
+    @validator("org")
+    def valid_org(cls, v):
+        return cls._validate_component(v, "org")
+
+    @validator("campaign")
+    def valid_campaign(cls, v):
+        return cls._validate_component(v, "campaign")
+
+    @validator("project")
+    def valid_project(cls, v):
+        return cls._validate_component(v, "project")
+
+    @root_validator
+    def check_scope_hierarchy(cls, values):
+        if not _hierarchy_valid(values):
+            raise InvalidScopeError(
+                f"Invalid scope hierarchy: {values}, cannot specify wildcard ('*')"
+                " in a scope component if a less specific scope component is not"
+                " given, unless all components are wildcards (*-*-*)."
+            )
+        return values
+
+    def to_tuple(self):
+        return (self.org, self.campaign, self.project)
+
+    @classmethod
+    def from_str(cls, string):
+        org, campaign, project = (i if i != "*" else None for i in string.split("-"))
+        return cls(org=org, campaign=campaign, project=project)
+
+    def is_superset(self, other: "Scope") -> bool:
+        """Return `True` if this Scope is a superset of another.
+
+        Check for a superset (not a proper superset) so that two equal scopes
+        also return `True`.
+
+        """
+        if self.org is not None and self.org != other.org:
+            return False
+        if self.campaign is not None and self.campaign != other.campaign:
+            return False
+        if self.project is not None and self.project != other.project:
+            return False
+        return True
+
+    def __repr__(self):  # pragma: no cover
+        return f"<Scope('{str(self)}')>"
+
+    def specific(self) -> bool:
+        """Return `True` if this Scope has no unspecified elements."""
+        return all(self.to_tuple())
+
+
+class InvalidGufeKeyError(ValueError): ...
+
+
+class ScopedKey(BaseModel):
+    """Unique identifier for GufeTokenizables in state store.
+
+    For this object, `org`, `campaign`, and `project` cannot contain wildcards.
+    In other words, the Scope of a ScopedKey must be *specific*.
+
+    """
+
+    gufe_key: GufeKey
+    org: str
+    campaign: str
+    project: str
+
+    class Config:
+        frozen = True
+
+    @validator("gufe_key")
+    def gufe_key_validator(cls, v):
+        v = str(v)
+
+        # GufeKey is of form <prefix>-<hex>
+        try:
+            _prefix, _token = v.split("-")
+        except ValueError:
+            raise InvalidGufeKeyError("gufe_key must be of the form '<prefix>-<hex>'")
+
+        # Normalize the input to NFC form
+        v_normalized = unicodedata.normalize("NFC", v)
+
+        # Allowed characters: letters, numbers, underscores, hyphens
+        allowed_chars = set(string.ascii_letters + string.digits + "_-")
+
+        if not set(v_normalized).issubset(allowed_chars):
+            raise InvalidGufeKeyError("gufe_key contains invalid characters")
+
+        # Cast to GufeKey
+        return GufeKey(v_normalized)
+
+    def __repr__(self):  # pragma: no cover
+        return f"<ScopedKey('{str(self)}')>"
+
+    def __str__(self):
+        return "-".join([self.gufe_key, self.org, self.campaign, self.project])
+
+    def __lt__(self, other):
+        return str(self) < str(other)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        return str(self) == str(other)
+
+    @classmethod
+    def from_str(cls, string):
+        try:
+            prefix, token, org, campaign, project = string.split("-")
+        except ValueError:
+            raise ValueError("input does not appear to be a `ScopedKey`")
+
+        gufe_key = GufeKey(f"{prefix}-{token}")
+
+        return cls(gufe_key=gufe_key, org=org, campaign=campaign, project=project)
+
+    @property
+    def scope(self):
+        return Scope(org=self.org, campaign=self.campaign, project=self.project)
+
+    @property
+    def qualname(self):
+        return self.gufe_key.split("-")[0]
+
+    def to_dict(self):
+        return self.dict()
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(**d)
+
+
+class InvalidScopeError(ValueError): ...
+
+
+def _is_wildcard(char: Union[str, None]) -> bool:
+    return char is None
+
+
+def _find_wildcard(scope_list: list) -> Union[int, None]:
+    """Finds the index of the first wildcard in a scope list."""
+    for i, scope in enumerate(scope_list):
+        if _is_wildcard(scope):
+            return i
+    return None
+
+
+def _hierarchy_valid(scope_dict: dict[str : Union[str, None]]) -> bool:
+    """Checks that the scope hierarchy is valid from a dictionary of scope components."""
+
+    org = scope_dict.get("org")
+    campaign = scope_dict.get("campaign")
+    project = scope_dict.get("project")
+    scope_list = [org, campaign, project]
+
+    first_wildcard_ix = _find_wildcard(scope_list)
+    if first_wildcard_ix is None:  # no wildcards, so we're good
+        return True
+
+    sublevels = scope_list[first_wildcard_ix:]
+    # now check if any of the sublevels are not wildcards
+    if any([not _is_wildcard(i) for i in sublevels]):
+        return False
+    return True

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/_alchemiscale.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/_alchemiscale.py
@@ -4,12 +4,13 @@
 
 """
 
-from typing import Optional, Union
-from pydantic import BaseModel, Field, validator, root_validator
-from gufe.tokenization import GufeKey
-from re import fullmatch
-import unicodedata
 import string
+import unicodedata
+from re import fullmatch
+from typing import Optional, Union
+
+from gufe.tokenization import GufeKey
+from pydantic import BaseModel, Field, root_validator, validator
 
 
 class Scope(BaseModel):

--- a/asapdiscovery-alchemy/pyproject.toml
+++ b/asapdiscovery-alchemy/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "Tooling for performing alchemical free energy calculations via OpenFE and alchemiscale"
 readme = "README.md"
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9,<3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/asapdiscovery-data/asapdiscovery/data/operators/deduplicator.py
+++ b/asapdiscovery-data/asapdiscovery/data/operators/deduplicator.py
@@ -1,5 +1,5 @@
 from asapdiscovery.data.schema.ligand import Ligand
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class LigandDeDuplicator(BaseModel):

--- a/asapdiscovery-data/asapdiscovery/data/operators/state_expanders/expansion_tag.py
+++ b/asapdiscovery-data/asapdiscovery/data/operators/state_expanders/expansion_tag.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 from asapdiscovery.data.schema.identifiers import LigandIdentifiers
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 if TYPE_CHECKING:
     from asapdiscovery.data.schema.ligand import Ligand

--- a/asapdiscovery-data/asapdiscovery/data/readers/meta_ligand_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/readers/meta_ligand_factory.py
@@ -6,7 +6,7 @@ from asapdiscovery.data.readers.molfile import MolFileFactory
 from asapdiscovery.data.schema.ligand import Ligand
 from asapdiscovery.data.services.postera.postera_factory import PosteraFactory
 from asapdiscovery.data.services.services_config import PosteraSettings
-from pydantic import BaseModel, Field, root_validator
+from pydantic.v1 import BaseModel, Field, root_validator
 
 logger = logging.getLogger(__name__)
 

--- a/asapdiscovery-data/asapdiscovery/data/schema/complex.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/complex.py
@@ -16,7 +16,7 @@ from asapdiscovery.data.schema.schema_base import DataModelAbstractBase
 from asapdiscovery.data.schema.target import PreppedTarget, Target
 from asapdiscovery.modeling.modeling import split_openeye_mol
 from asapdiscovery.modeling.schema import MoleculeFilter
-from pydantic import Field
+from pydantic.v1 import Field
 
 logger = logging.getLogger(__name__)
 

--- a/asapdiscovery-data/asapdiscovery/data/schema/experimental.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/experimental.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class ExperimentalCompoundData(BaseModel):

--- a/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
@@ -2,7 +2,7 @@ from typing import Any, Literal, Optional
 
 from asapdiscovery.data.schema.schema_base import DataModelAbstractBase
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 
 class LigandIdentifiers(DataModelAbstractBase):

--- a/asapdiscovery-data/asapdiscovery/data/schema/legacy.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/legacy.py
@@ -1,5 +1,5 @@
 from asapdiscovery.data.schema.experimental import ExperimentalCompoundData
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class CrystalCompoundData(BaseModel):

--- a/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
@@ -37,7 +37,7 @@ from asapdiscovery.data.schema.identifiers import (
     LigandProvenance,
 )
 from asapdiscovery.data.schema.schema_base import DataStorageType
-from pydantic import Field, root_validator, validator
+from pydantic.v1 import Field, root_validator, validator
 
 from .experimental import ExperimentalCompoundData
 from .schema_base import (
@@ -145,10 +145,9 @@ class Ligand(DataModelAbstractBase):
         description="SDF file stored as a string to hold internal data state",
         repr=False,
     )
-    data_format: DataStorageType = Field(
+    data_format: Literal[DataStorageType] = Field(
         DataStorageType.sdf,
         description="Enum describing the data storage method",
-        const=True,
         allow_mutation=False,
     )
 

--- a/asapdiscovery-data/asapdiscovery/data/schema/pairs.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/pairs.py
@@ -3,7 +3,7 @@ from typing import Any, ClassVar
 
 from asapdiscovery.data.schema.complex import Complex
 from asapdiscovery.data.schema.ligand import Ligand
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 

--- a/asapdiscovery-data/asapdiscovery/data/schema/schema_base.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/schema_base.py
@@ -4,7 +4,7 @@ import json
 from enum import Enum
 from pathlib import Path
 
-from pydantic import BaseModel, ByteSize
+from pydantic.v1 import BaseModel, ByteSize
 
 _SCHEMA_VERSION = "0.1.0"
 

--- a/asapdiscovery-data/asapdiscovery/data/schema/sets.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/sets.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar
 from asapdiscovery.data.schema.complex import Complex
 from asapdiscovery.data.schema.ligand import Ligand
 from asapdiscovery.data.schema.pairs import CompoundStructurePair
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 

--- a/asapdiscovery-data/asapdiscovery/data/schema/target.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/target.py
@@ -20,7 +20,7 @@ from asapdiscovery.modeling.modeling import (  # TODO: move to backend
     split_openeye_mol,
 )
 from asapdiscovery.modeling.schema import MoleculeFilter  # TODO: move to backend
-from pydantic import Field, root_validator
+from pydantic.v1 import Field, root_validator
 
 from .schema_base import (
     DataModelAbstractBase,

--- a/asapdiscovery-data/asapdiscovery/data/services/services_config.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/services_config.py
@@ -2,7 +2,8 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from pydantic import BaseSettings, Field, validator
+from pydantic import Field, validator
+from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
 

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_complex_schema.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_complex_schema.py
@@ -2,7 +2,7 @@ import pytest
 from asapdiscovery.data.backend.openeye import load_openeye_pdb
 from asapdiscovery.data.schema.complex import Complex, PreppedComplex
 from asapdiscovery.data.testing.test_resources import fetch_test_file
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 @pytest.fixture(scope="session")

--- a/asapdiscovery-data/asapdiscovery/data/util/utils.py
+++ b/asapdiscovery-data/asapdiscovery/data/util/utils.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 
 import numpy as np
 import pandas
-import pydantic
+import pydantic.v1
 from asapdiscovery.data.backend.openeye import oechem
 from asapdiscovery.data.schema.experimental import ExperimentalCompoundData
 from asapdiscovery.data.schema.legacy import EnantiomerPair, EnantiomerPairList

--- a/devtools/conda-envs/asapdiscovery-macOS-12.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-12.yml
@@ -92,11 +92,11 @@ dependencies:
   - logomaker
 
   # simulation
-  - openfe >=1.1.0
-  - gufe >=1.0.0
+  - openfe >=1.3.0
+  - gufe >=1.2.0
   - httpx
   - perses >=0.10.2
   - kartograf
   - rich
-  - alchemiscale-client >=0.5.1
+  - alchemiscale-client >=0.6.1
   - cinnabar >=0.4.1

--- a/devtools/conda-envs/asapdiscovery-macOS-12.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-12.yml
@@ -25,13 +25,14 @@ dependencies:
   - mdanalysis
   - openff-toolkit
   - openff-fragmenter <0.2.2
-  - openff-bespokefit >=0.4.0
+  #- openff-bespokefit >=0.4.0
   - openff-forcefields >=2024.04.0
   - openeye-toolkits # may need  <2023.2.3 for lilac GLIBC
   - openmmforcefields >= 0.13.0
   - pandas
   - pebble
-  - pydantic >=1.10.8,<2.0.0a0
+  - pydantic >2
+  - pydantic-settings
   - rdkit
   - seaborn
   - panel
@@ -55,19 +56,19 @@ dependencies:
   - multimethod
 
   # ml
-  - pytorch
-  - pytorch_geometric >=2.5.0
-  - pytorch_cluster
-  - pytorch_scatter
-  - pytorch_sparse
-  - numpy
-  - h5py
-  - e3nn
-  - dgl <=2.0.0
-  - dgllife
-  - pooch
-  - mtenn =0.6.2
-  - wandb
+  #- pytorch
+  #- pytorch_geometric >=2.5.0
+  #- pytorch_cluster
+  #- pytorch_scatter
+  #- pytorch_sparse
+  #- numpy
+  #- h5py
+  #- e3nn
+  #- dgl <=2.0.0
+  #- dgllife
+  #- pooch
+  #- mtenn =0.6.2
+  #- wandb
 
   # md
   - openmm

--- a/devtools/conda-envs/asapdiscovery-macOS-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-latest.yml
@@ -90,11 +90,11 @@ dependencies:
   - logomaker
 
   # simulation
-  - openfe >=1.1.0
-  - gufe >=1.0.0
+  - openfe >=1.3.0
+  - gufe >=1.2.0
   - httpx
   - perses >=0.10.2
   - kartograf
   - rich
-  - alchemiscale-client >=0.5.1
+  - alchemiscale-client >=0.6.1
   - cinnabar >=0.4.1

--- a/devtools/conda-envs/asapdiscovery-macOS-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-latest.yml
@@ -25,11 +25,11 @@ dependencies:
   - openff-toolkit
   - openff-forcefields >=2024.04.0
   - openeye-toolkits # may need  <2023.2.3 for lilac GLIBC
-  - openff-bespokefit >=0.4.0
+  #- openff-bespokefit >=0.4.0
   - openmmforcefields >= 0.13.0
   - pandas
   - pebble
-  - pydantic >=1.10.8,<2.0.0a0
+  - pydantic >2
   - rdkit
   - seaborn
   - pebble
@@ -52,19 +52,19 @@ dependencies:
   - multimethod
 
   # ml
-  - pytorch
-  - pytorch_geometric >=2.5.0
-  - pytorch_cluster
-  - pytorch_scatter
-  - pytorch_sparse
-  - numpy
-  - h5py
-  - e3nn
-  - dgl <=2.0.0
-  - dgllife
-  - pooch
-  - mtenn =0.6.2
-  - wandb
+  #- pytorch
+  #- pytorch_geometric >=2.5.0
+  #- pytorch_cluster
+  #- pytorch_scatter
+  #- pytorch_sparse
+  #- numpy
+  #- h5py
+  #- e3nn
+  #- dgl <=2.0.0
+  #- dgllife
+  #- pooch
+  #- mtenn =0.6.2
+  #- wandb
 
   # md
   - openmm

--- a/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
@@ -93,11 +93,11 @@ dependencies:
   - logomaker
 
   # simulation
-  - openfe >=1.1.0
-  - gufe >=1.0.0
+  - openfe >=1.3.0
+  - gufe >=1.2.0
   - httpx
   - perses >=0.10.2
   - kartograf
   - rich
-  - alchemiscale-client >=0.5.1
+  - alchemiscale-client >=0.6.1
   - cinnabar >=0.4.1

--- a/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
@@ -24,13 +24,13 @@ dependencies:
   - mdanalysis
   - openff-toolkit
   - openff-fragmenter <0.2.2
-  - openff-bespokefit >=0.4.0
+  #- openff-bespokefit >=0.4.0
   - openff-forcefields >=2024.04.0
   - openeye-toolkits # may need  <2023.2.3 for lilac GLIBC
   - openmmforcefields >= 0.13.0
   - pandas
   - pebble
-  - pydantic >=1.10.8,<2.0.0a0
+  - pydantic >2
   - rdkit
   - seaborn
   - panel
@@ -54,19 +54,19 @@ dependencies:
   - multimethod
 
   # ml
-  - pytorch
-  - pytorch_geometric >=2.5.0
-  - pytorch_cluster
-  - pytorch_scatter
-  - pytorch_sparse
-  - numpy
-  - h5py
-  - e3nn
-  - dgl <=2.0.0
-  - dgllife
-  - pooch
-  - mtenn =0.6.2
-  - wandb
+  #- pytorch
+  #- pytorch_geometric >=2.5.0
+  #- pytorch_cluster
+  #- pytorch_scatter
+  #- pytorch_sparse
+  #- numpy
+  #- h5py
+  #- e3nn
+  #- dgl <=2.0.0
+  #- dgllife
+  #- pooch
+  #- mtenn =0.6.2
+  #- wandb
 
   # md
   - openmm


### PR DESCRIPTION
## Description

Changes necessary for using `alchemiscale` v0.6.x.

Some of these changes may serve as temporary workarounds until `openff-bespokefit` and `openff-qcsubmit` use `pydantic` v2.0 internally.

## Status
- [ ] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
