### PR TITLE
Change CDD Vault GET requests with bodies to POST

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/services/cdd/cdd_api.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/cdd/cdd_api.py
@@ -71,8 +71,8 @@ class CDDAPI(_BaseWebAPI):
             mol_data["molecules"] = compound_ids
             mol_data["async"] = "true"
         result = json.loads(
-            self._session.get(
-                url=self.api_url + "molecules/", json=mol_data
+            self._session.post(
+                url=self.api_url + "molecules/query", json=mol_data
             ).content.decode()
         )
         # handle missing molecules, originally found when searching moonshot data
@@ -87,8 +87,8 @@ class CDDAPI(_BaseWebAPI):
             mol_data["molecules"] = to_find
             # run the search again
             result = json.loads(
-                self._session.get(
-                    url=self.api_url + "molecules/", json=mol_data
+                self._session.post(
+                    url=self.api_url + "molecules/query", json=mol_data
                 ).content.decode()
             )
         if "async" in mol_data:
@@ -114,7 +114,7 @@ class CDDAPI(_BaseWebAPI):
         protocol_data = {}
         if protocol_names is not None:
             protocol_data["names"] = protocol_names
-        result = self._session.get(url=self.api_url + "protocols", json=protocol_data)
+        result = self._session.post(url=self.api_url + "protocols/query", json=protocol_data)
         result_data = json.loads(result.content.decode())
         return result_data["objects"]
 
@@ -143,7 +143,7 @@ class CDDAPI(_BaseWebAPI):
             readout_data["type"] = types
         if molecule_ids is not None:
             readout_data["molecules"] = molecule_ids
-        result = self._session.get(url=self.api_url + "readout_rows", json=readout_data)
+        result = self._session.post(url=self.api_url + "readout_rows/query", json=readout_data)
         request_id = json.loads(result.content.decode())["id"]
         result_data = self.get_async_export(job_id=request_id)
         if result_data["count"] == 0:

--- a/asapdiscovery-data/asapdiscovery/data/services/cdd/cdd_download.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/cdd/cdd_download.py
@@ -88,7 +88,7 @@ def download_url(search_url, header, vault=None, timeout=5000, retry_delay=10):
         )
         sys.exit("Export failed")
 
-    # Send GET request for final export
+    # Send GET request for final export (no body, so GET is correct)
     result_url = f"{CDD_URL}/{vault}/exports/{export_id}"
     response = requests.get(result_url, headers=header)
 

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_cdd_download.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_cdd_download.py
@@ -424,7 +424,7 @@ def test_cdd_api_get_molecules(mocked_cdd_api, search, expected_result):
             return {"id": "1"}
 
     with requests_mock.Mocker() as m:
-        m.get(mocked_cdd_api.api_url + "molecules/", json=get_mols)
+        m.post(mocked_cdd_api.api_url + "molecules/query", json=get_mols)
         m.get(
             mocked_cdd_api.api_url + "exports/1",
             json={
@@ -448,7 +448,7 @@ def test_cdd_api_get_molecules_missing(mocked_cdd_api):
             return {"id": "1"}
 
     with requests_mock.Mocker() as m:
-        m.get(mocked_cdd_api.api_url + "molecules/", json=get_mols)
+        m.post(mocked_cdd_api.api_url + "molecules/query", json=get_mols)
         m.get(
             mocked_cdd_api.api_url + "exports/1",
             json={
@@ -468,7 +468,7 @@ def test_cdd_api_get_protocol(mocked_cdd_api, protocol_names):
     """Test pulling down protocol data."""
 
     with requests_mock.Mocker() as m:
-        m.get(mocked_cdd_api.api_url + "protocols", json={"objects": [{"id": 1}]})
+        m.post(mocked_cdd_api.api_url + "protocols/query", json={"objects": [{"id": 1}]})
         result = mocked_cdd_api.get_protocols(protocol_names=protocol_names)
         assert result == [{"id": 1}]
 
@@ -477,7 +477,7 @@ def test_cdd_api_readout_rows(mocked_cdd_api):
     """Test pulling down readout data using the api"""
 
     with requests_mock.Mocker() as m:
-        m.get(mocked_cdd_api.api_url + "readout_rows", json={"id": 2})
+        m.post(mocked_cdd_api.api_url + "readout_rows/query", json={"id": 2})
         m.get(
             mocked_cdd_api.api_url + "exports/2",
             json={"count": 2, "objects": [{"id": 2}, {"id": 3}]},
@@ -538,13 +538,13 @@ def test_cdd_api_get_ic50(mocked_cdd_api):
     }
     with requests_mock.Mocker() as m:
         # mock the required protocols
-        m.get(mocked_cdd_api.api_url + "protocols", json=mock_protocol_response)
+        m.post(mocked_cdd_api.api_url + "protocols/query", json=mock_protocol_response)
         # mock the return of the async request
-        m.get(mocked_cdd_api.api_url + "readout_rows", json={"id": 100})
+        m.post(mocked_cdd_api.api_url + "readout_rows/query", json={"id": 100})
         # mock the export request for the readout rows
         m.get(mocked_cdd_api.api_url + "exports/100", json=mock_readout_response)
         # mock the molecule async request
-        m.get(mocked_cdd_api.api_url + "molecules/", json={"id": 101})
+        m.post(mocked_cdd_api.api_url + "molecules/query", json={"id": 101})
         m.get(mocked_cdd_api.api_url + "exports/101", json=mock_molecule_response)
         ic50_df = mocked_cdd_api.get_ic50_data(protocol_name=assay_name)
         # check the values were collected correctly


### PR DESCRIPTION
## Summary
- Converts GET requests that send JSON bodies to POST requests with `/query` URL suffix, per [CDD API migration guide](https://support.collaborativedrug.com/hc/en-us/articles/115005684626-General-API-Parameters)
- Affects `molecules/`, `protocols`, and `readout_rows` endpoints in `cdd_api.py`
- Updates corresponding test mocks in `test_cdd_download.py`
- GET requests without bodies (searches, export polling, export download) are unchanged

Closes #1285

## Test plan
- [ ] Verify mocked CDD API tests pass (`pytest asapdiscovery-data/asapdiscovery/data/tests/test_cdd_download.py`)
- [x] Validate against live CDD Vault with API token if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)