### PR TITLE
Update repo ownership references and drop obsolete Docker install docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@ Notable points that this PR has either accomplished or will accomplish.
 
 
 ## Developers certificate of origin
-- [ ] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
+- [ ] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/asapdiscovery/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 asapdiscovery
 =============
 [//]: # (Badges)
-[![codecov](https://codecov.io/gh/choderalab/asapdiscovery/branch/main/graph/badge.svg)](https://codecov.io/gh/choderalab/asapdiscovery/branch/main)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/choderalab/asapdiscovery/main.svg)](https://results.pre-commit.ci/latest/github/choderalab/asapdiscovery/main)
+[![codecov](https://codecov.io/gh/asapdiscovery/asapdiscovery/branch/main/graph/badge.svg)](https://codecov.io/gh/asapdiscovery/asapdiscovery/branch/main)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/asapdiscovery/asapdiscovery/main.svg)](https://results.pre-commit.ci/latest/github/asapdiscovery/asapdiscovery/main)
 [![Documentation Status](https://readthedocs.org/projects/asapdiscovery/badge/?version=latest)](https://asapdiscovery.readthedocs.io/en/latest/?badge=latest)
 
 
@@ -69,7 +69,7 @@ To install an `asapdiscovery` package hosted in this repository, we recommend th
 1. Clone the repository, then enter the source tree:
 
     ```
-    git clone https://github.com/choderalab/asapdiscovery.git
+    git clone https://github.com/asapdiscovery/asapdiscovery.git
     cd asapdiscovery
     ```
 

--- a/asapdiscovery-alchemy/pyproject.toml
+++ b/asapdiscovery-alchemy/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/choderalab/asapdiscovery"
-"Bug Tracker" = "https://github.com/choderalab/asapdiscovery/issues"
+"Homepage" = "https://github.com/asapdiscovery/asapdiscovery"
+"Bug Tracker" = "https://github.com/asapdiscovery/asapdiscovery/issues"
 
 [project.scripts]
 asap-alchemy = "asapdiscovery.alchemy.cli.cli:alchemy"

--- a/asapdiscovery-alchemy/pyproject.toml
+++ b/asapdiscovery-alchemy/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
   { name="David Dotson", email="david.dotson@choderalab.org" },
+  { name="Hugo MacDermott-Opeskin", email="hugo.macdermott@choderalab.org" },
+  { name="Jenke Scheen", email="jenke.scheen@choderalab.org" },
+  { name="Alex Payne", email="alex.payne@choderalab.org" },
 ]
 description = "Tooling for performing alchemical free energy calculations via OpenFE and alchemiscale"
 readme = "README.md"

--- a/asapdiscovery-alchemy/pyproject.toml
+++ b/asapdiscovery-alchemy/pyproject.toml
@@ -8,6 +8,7 @@ name = "asapdiscovery-alchemy"
 dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
+  { name="David Dotson", email="david.dotson@choderalab.org" },
 ]
 description = "Tooling for performing alchemical free energy calculations via OpenFE and alchemiscale"
 readme = "README.md"

--- a/asapdiscovery-cli/pyproject.toml
+++ b/asapdiscovery-cli/pyproject.toml
@@ -28,8 +28,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/choderalab/asapdiscovery"
-"Bug Tracker" = "https://github.com/choderalab/asapdiscovery/issues"
+"Homepage" = "https://github.com/asapdiscovery/asapdiscovery"
+"Bug Tracker" = "https://github.com/asapdiscovery/asapdiscovery/issues"
 
 [project.scripts]
 asap-cli = "asapdiscovery.cli.cli:cli"

--- a/asapdiscovery-cli/pyproject.toml
+++ b/asapdiscovery-cli/pyproject.toml
@@ -8,6 +8,7 @@ name = "asapdiscovery-cli"
 dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
+  { name="David Dotson", email="david.dotson@choderalab.org" },
 ]
 description = "API and scripts related to downloading and interacting with data from the Collaborative Drug Discovery Vault, Fragalysis, and the PDB"
 readme = "README.md"

--- a/asapdiscovery-cli/pyproject.toml
+++ b/asapdiscovery-cli/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
   { name="David Dotson", email="david.dotson@choderalab.org" },
+  { name="Hugo MacDermott-Opeskin", email="hugo.macdermott@choderalab.org" },
+  { name="Jenke Scheen", email="jenke.scheen@choderalab.org" },
+  { name="Alex Payne", email="alex.payne@choderalab.org" },
 ]
 description = "API and scripts related to downloading and interacting with data from the Collaborative Drug Discovery Vault, Fragalysis, and the PDB"
 readme = "README.md"

--- a/asapdiscovery-data/pyproject.toml
+++ b/asapdiscovery-data/pyproject.toml
@@ -8,6 +8,7 @@ name = "asapdiscovery-data"
 dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
+  { name="David Dotson", email="david.dotson@choderalab.org" },
 ]
 description = "API and scripts related to downloading and interacting with data from the Collaborative Drug Discovery Vault, Fragalysis, and the PDB"
 readme = "README.md"

--- a/asapdiscovery-data/pyproject.toml
+++ b/asapdiscovery-data/pyproject.toml
@@ -24,8 +24,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/choderalab/asapdiscovery"
-"Bug Tracker" = "https://github.com/choderalab/asapdiscovery/issues"
+"Homepage" = "https://github.com/asapdiscovery/asapdiscovery"
+"Bug Tracker" = "https://github.com/asapdiscovery/asapdiscovery/issues"
 
 [project.scripts]
 cdd-to-schema = "asapdiscovery.data.scripts.cdd_to_schema:main"

--- a/asapdiscovery-data/pyproject.toml
+++ b/asapdiscovery-data/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
   { name="David Dotson", email="david.dotson@choderalab.org" },
+  { name="Hugo MacDermott-Opeskin", email="hugo.macdermott@choderalab.org" },
+  { name="Jenke Scheen", email="jenke.scheen@choderalab.org" },
+  { name="Alex Payne", email="alex.payne@choderalab.org" },
 ]
 description = "API and scripts related to downloading and interacting with data from the Collaborative Drug Discovery Vault, Fragalysis, and the PDB"
 readme = "README.md"

--- a/asapdiscovery-dataviz/pyproject.toml
+++ b/asapdiscovery-dataviz/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
   { name="David Dotson", email="david.dotson@choderalab.org" },
+  { name="Hugo MacDermott-Opeskin", email="hugo.macdermott@choderalab.org" },
+  { name="Jenke Scheen", email="jenke.scheen@choderalab.org" },
+  { name="Alex Payne", email="alex.payne@choderalab.org" },
 ]
 description = "API and scripts related to visualizing docking results"
 readme = "README.md"

--- a/asapdiscovery-dataviz/pyproject.toml
+++ b/asapdiscovery-dataviz/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/choderalab/asapdiscovery"
-"Bug Tracker" = "https://github.com/choderalab/asapdiscovery/issues"
+"Homepage" = "https://github.com/asapdiscovery/asapdiscovery"
+"Bug Tracker" = "https://github.com/asapdiscovery/asapdiscovery/issues"
 
 
 [tool.setuptools.packages.find]

--- a/asapdiscovery-dataviz/pyproject.toml
+++ b/asapdiscovery-dataviz/pyproject.toml
@@ -8,6 +8,7 @@ name = "asapdiscovery-dataviz"
 dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
+  { name="David Dotson", email="david.dotson@choderalab.org" },
 ]
 description = "API and scripts related to visualizing docking results"
 readme = "README.md"

--- a/asapdiscovery-docking/asapdiscovery/docking/schema/pose_generation.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/schema/pose_generation.py
@@ -381,7 +381,7 @@ class OpenEyeConstrainedPoseGenerator(_BasicConstrainedPoseGenerator):
         input_mol = oechem.OEMol(reference_ligand)
         oechem.OESuppressHydrogens(input_mol)
         # build a query mol which allows for wild card matches
-        # <https://github.com/choderalab/asapdiscovery/pull/430#issuecomment-1702360130>
+        # <https://github.com/asapdiscovery/asapdiscovery/pull/430#issuecomment-1702360130>
         smarts_mol = oechem.OEGraphMol()
         oechem.OESmilesToMol(smarts_mol, core_smarts)
         pattern_query = oechem.OEQMol(smarts_mol)

--- a/asapdiscovery-docking/pyproject.toml
+++ b/asapdiscovery-docking/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
   { name="David Dotson", email="david.dotson@choderalab.org" },
+  { name="Hugo MacDermott-Opeskin", email="hugo.macdermott@choderalab.org" },
+  { name="Jenke Scheen", email="jenke.scheen@choderalab.org" },
+  { name="Alex Payne", email="alex.payne@choderalab.org" },
 ]
 description = "API and scripts related to running docking and preparing the input structures"
 readme = "README.md"

--- a/asapdiscovery-docking/pyproject.toml
+++ b/asapdiscovery-docking/pyproject.toml
@@ -8,6 +8,7 @@ name = "asapdiscovery-docking"
 dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
+  { name="David Dotson", email="david.dotson@choderalab.org" },
 ]
 description = "API and scripts related to running docking and preparing the input structures"
 readme = "README.md"

--- a/asapdiscovery-docking/pyproject.toml
+++ b/asapdiscovery-docking/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/choderalab/asapdiscovery"
-"Bug Tracker" = "https://github.com/choderalab/asapdiscovery/issues"
+"Homepage" = "https://github.com/asapdiscovery/asapdiscovery"
+"Bug Tracker" = "https://github.com/asapdiscovery/asapdiscovery/issues"
 
 [project.scripts]
 make-docked-complexes = "asapdiscovery.docking.scripts.make_docked_complexes_schema_v2:main"

--- a/asapdiscovery-ml/pyproject.toml
+++ b/asapdiscovery-ml/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
   { name="David Dotson", email="david.dotson@choderalab.org" },
+  { name="Hugo MacDermott-Opeskin", email="hugo.macdermott@choderalab.org" },
+  { name="Jenke Scheen", email="jenke.scheen@choderalab.org" },
+  { name="Alex Payne", email="alex.payne@choderalab.org" },
 ]
 description = "API and scripts related to machine learning training and inference using the ASAP data"
 readme = "README.md"

--- a/asapdiscovery-ml/pyproject.toml
+++ b/asapdiscovery-ml/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/choderalab/asapdiscovery"
-"Bug Tracker" = "https://github.com/choderalab/asapdiscovery/issues"
+"Homepage" = "https://github.com/asapdiscovery/asapdiscovery"
+"Bug Tracker" = "https://github.com/asapdiscovery/asapdiscovery/issues"
 
 [project.scripts]
 asap-ml = "asapdiscovery.ml.cli:ml"

--- a/asapdiscovery-ml/pyproject.toml
+++ b/asapdiscovery-ml/pyproject.toml
@@ -8,6 +8,7 @@ name = "asapdiscovery-ml"
 dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
+  { name="David Dotson", email="david.dotson@choderalab.org" },
 ]
 description = "API and scripts related to machine learning training and inference using the ASAP data"
 readme = "README.md"

--- a/asapdiscovery-modeling/asapdiscovery/modeling/schema.py
+++ b/asapdiscovery-modeling/asapdiscovery/modeling/schema.py
@@ -116,7 +116,7 @@ class PreppedTarget(DataModelAbstractBase):
         """
         oedu = self.to_oedu()
         _, oe_receptor, _ = split_openeye_design_unit(du=oedu)
-        # As advised by Alex <https://github.com/choderalab/asapdiscovery/pull/608#discussion_r1388067468>
+        # As advised by Alex <https://github.com/asapdiscovery/asapdiscovery/pull/608#discussion_r1388067468>
         openeye_perceive_residues(oe_receptor)
         save_openeye_pdb(oe_receptor, pdb_fn=filename)
 

--- a/asapdiscovery-modeling/pyproject.toml
+++ b/asapdiscovery-modeling/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/choderalab/asapdiscovery"
-"Bug Tracker" = "https://github.com/choderalab/asapdiscovery/issues"
+"Homepage" = "https://github.com/asapdiscovery/asapdiscovery"
+"Bug Tracker" = "https://github.com/asapdiscovery/asapdiscovery/issues"
 
 [project.scripts]
 blast-search = "asapdiscovery.modeling.scripts.blast_search:main"

--- a/asapdiscovery-modeling/pyproject.toml
+++ b/asapdiscovery-modeling/pyproject.toml
@@ -8,6 +8,7 @@ name = "asapdiscovery-modeling"
 dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
+  { name="David Dotson", email="david.dotson@choderalab.org" },
 ]
 description = "API and scripts for preparing protein and ligand models for downstream applications"
 readme = "README.md"

--- a/asapdiscovery-modeling/pyproject.toml
+++ b/asapdiscovery-modeling/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
   { name="David Dotson", email="david.dotson@choderalab.org" },
+  { name="Hugo MacDermott-Opeskin", email="hugo.macdermott@choderalab.org" },
+  { name="Jenke Scheen", email="jenke.scheen@choderalab.org" },
+  { name="Alex Payne", email="alex.payne@choderalab.org" },
 ]
 description = "API and scripts for preparing protein and ligand models for downstream applications"
 readme = "README.md"

--- a/asapdiscovery-simulation/pyproject.toml
+++ b/asapdiscovery-simulation/pyproject.toml
@@ -8,6 +8,7 @@ name = "asapdiscovery-simulation"
 dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
+  { name="David Dotson", email="david.dotson@choderalab.org" },
 ]
 description = "API and scripts for running molecular dynamics simulations"
 readme = "README.md"

--- a/asapdiscovery-simulation/pyproject.toml
+++ b/asapdiscovery-simulation/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/choderalab/asapdiscovery"
-"Bug Tracker" = "https://github.com/choderalab/asapdiscovery/issues"
+"Homepage" = "https://github.com/asapdiscovery/asapdiscovery"
+"Bug Tracker" = "https://github.com/asapdiscovery/asapdiscovery/issues"
 
 [project.scripts]
 

--- a/asapdiscovery-simulation/pyproject.toml
+++ b/asapdiscovery-simulation/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
   { name="David Dotson", email="david.dotson@choderalab.org" },
+  { name="Hugo MacDermott-Opeskin", email="hugo.macdermott@choderalab.org" },
+  { name="Jenke Scheen", email="jenke.scheen@choderalab.org" },
+  { name="Alex Payne", email="alex.payne@choderalab.org" },
 ]
 description = "API and scripts for running molecular dynamics simulations"
 readme = "README.md"

--- a/asapdiscovery-spectrum/pyproject.toml
+++ b/asapdiscovery-spectrum/pyproject.toml
@@ -8,6 +8,7 @@ name = "asapdiscovery-spectrum"
 dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
+  { name="David Dotson", email="david.dotson@choderalab.org" },
 ]
 description = "API and scripts related to downloading and interacting with data from the Collaborative Drug Discovery Vault, Fragalysis, and the PDB"
 readme = "README.md"

--- a/asapdiscovery-spectrum/pyproject.toml
+++ b/asapdiscovery-spectrum/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/choderalab/asapdiscovery"
-"Bug Tracker" = "https://github.com/choderalab/asapdiscovery/issues"
+"Homepage" = "https://github.com/asapdiscovery/asapdiscovery"
+"Bug Tracker" = "https://github.com/asapdiscovery/asapdiscovery/issues"
 
 [project.scripts]
 asap-spectrum = "asapdiscovery.spectrum.cli:spectrum"

--- a/asapdiscovery-spectrum/pyproject.toml
+++ b/asapdiscovery-spectrum/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
   { name="David Dotson", email="david.dotson@choderalab.org" },
+  { name="Hugo MacDermott-Opeskin", email="hugo.macdermott@choderalab.org" },
+  { name="Jenke Scheen", email="jenke.scheen@choderalab.org" },
+  { name="Alex Payne", email="alex.payne@choderalab.org" },
 ]
 description = "API and scripts related to downloading and interacting with data from the Collaborative Drug Discovery Vault, Fragalysis, and the PDB"
 readme = "README.md"

--- a/asapdiscovery-workflows/pyproject.toml
+++ b/asapdiscovery-workflows/pyproject.toml
@@ -9,6 +9,9 @@ dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
   { name="David Dotson", email="david.dotson@choderalab.org" },
+  { name="Hugo MacDermott-Opeskin", email="hugo.macdermott@choderalab.org" },
+  { name="Jenke Scheen", email="jenke.scheen@choderalab.org" },
+  { name="Alex Payne", email="alex.payne@choderalab.org" },
 ]
 description = "API and scripts related to running docking and preparing the input structures"
 readme = "README.md"

--- a/asapdiscovery-workflows/pyproject.toml
+++ b/asapdiscovery-workflows/pyproject.toml
@@ -8,6 +8,7 @@ name = "asapdiscovery-workflows"
 dynamic = ["version"]
 authors = [
   { name="ASAP Discovery", email="benjamin.kaminow@choderalab.org" },
+  { name="David Dotson", email="david.dotson@choderalab.org" },
 ]
 description = "API and scripts related to running docking and preparing the input structures"
 readme = "README.md"

--- a/asapdiscovery-workflows/pyproject.toml
+++ b/asapdiscovery-workflows/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/choderalab/asapdiscovery"
-"Bug Tracker" = "https://github.com/choderalab/asapdiscovery/issues"
+"Homepage" = "https://github.com/asapdiscovery/asapdiscovery"
+"Bug Tracker" = "https://github.com/asapdiscovery/asapdiscovery/issues"
 
 [project.scripts]
 asap-docking = "asapdiscovery.workflows.docking_workflows.cli:docking"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -221,7 +221,7 @@ nbsphinx_prolog = (
     .. nbinfo::
         This page was generated from `{{ docpath }}`__.
 
-    __ https://github.com/choderalab/asapdiscovery/tree/main/
+    __ https://github.com/asapdiscovery/asapdiscovery/tree/main/
         """
     + r"{{ docpath }}"
 )

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,9 @@ mamba install -c openeye openeye-toolkits
 Developer installation from source
 ----------------------------------
 
-`asapdiscovery` is a namespace package split across 11 subpackages, each independently installable with its own conda environment. Development uses [`just`](https://github.com/casey/just) as a task runner over this layout. Install it first if you don't have it (e.g. `mamba install -c conda-forge just`).
+`asapdiscovery` is a namespace package split across 11 subpackages, each independently installable with its own conda environment.
+Development uses [`just`](https://github.com/casey/just) as a task runner over this layout.
+Install it first if you don't have it (e.g. `mamba install -c conda-forge just`).
 
 Clone the repository:
 
@@ -35,16 +37,18 @@ git clone git@github.com:asapdiscovery/asapdiscovery.git
 cd asapdiscovery
 ```
 
-Create a conda environment for the subpackage(s) you want to work on. Per-subpackage environment files live under `devtools/conda-envs/<platform>/`, plus an `all` environment that covers everything. The `just create-env` recipe picks the right platform automatically:
+Create a conda environment for the subpackage(s) you want to work on.
+Per-subpackage environment files live under `devtools/conda-envs/<platform>/`, plus an `all` environment that covers everything.
+The `just create-env` recipe picks the right platform automatically:
 
 ```bash
 # Environment with every subpackage's dependencies
-just create-env all asapdiscovery
+just create-env all <env-name>
 
 # Or for a single subpackage (e.g. data)
-just create-env data asapdiscovery-data
+just create-env data <env-name>
 
-mamba activate asapdiscovery   # or your chosen env name
+mamba activate <env-name> # or your chosen env name
 ```
 
 Install the subpackages in editable mode. To install everything:
@@ -65,4 +69,6 @@ To inspect the internal dependency graph:
 just deps
 ```
 
-Run tests for a single subpackage with `just test <pkg>`, or run them all sequentially with `just test-all`. Apply pre-commit linters across the repo with `just lint`. Run `just` with no arguments to list every available recipe.
+Run tests for a single subpackage with `just test <pkg>`, or run them all sequentially with `just test-all`.
+Apply pre-commit linters across the repo with `just lint`.
+Run `just` with no arguments to list every available recipe.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,14 +26,43 @@ mamba install -c openeye openeye-toolkits
 Developer installation from source
 ----------------------------------
 
-To install `asapdiscovery` from source, you will need to clone the repository, setup a compatible environment with mamba (or conda) and install the package using `pip`. You can do this using the following commands:
+`asapdiscovery` is a namespace package split across 11 subpackages, each independently installable with its own conda environment. Development uses [`just`](https://github.com/casey/just) as a task runner over this layout. Install it first if you don't have it (e.g. `mamba install -c conda-forge just`).
+
+Clone the repository:
 
 ```bash
 git clone git@github.com:asapdiscovery/asapdiscovery.git
 cd asapdiscovery
-mamba env create -f devtools/conda-envs/asapdiscovery-ubuntu-latest.yml # chose relevant file for your platform
-mamba activate asapdiscovery
-cp devtools/repo_installer.sh . && chmod +x repo_installer.sh && ./repo_installer.sh
 ```
 
-This will install the package in editable mode, so you can make changes to the code and see the changes reflected in the package. You can also run the tests using the following command:
+Create a conda environment for the subpackage(s) you want to work on. Per-subpackage environment files live under `devtools/conda-envs/<platform>/`, plus an `all` environment that covers everything. The `just create-env` recipe picks the right platform automatically:
+
+```bash
+# Environment with every subpackage's dependencies
+just create-env all asapdiscovery
+
+# Or for a single subpackage (e.g. data)
+just create-env data asapdiscovery-data
+
+mamba activate asapdiscovery   # or your chosen env name
+```
+
+Install the subpackages in editable mode. To install everything:
+
+```bash
+just install-all
+```
+
+To install a single subpackage along with its internal dependencies in topological order:
+
+```bash
+just install-with-deps alchemy
+```
+
+To inspect the internal dependency graph:
+
+```bash
+just deps
+```
+
+Run tests for a single subpackage with `just test <pkg>`, or run them all sequentially with `just test-all`. Apply pre-commit linters across the repo with `just lint`. Run `just` with no arguments to list every available recipe.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,11 +3,10 @@ Installation
 
 This page details how to get started with `asapdiscovery` and how to install it on your system.
 
-There are three ways to install `asapdiscovery`:
+There are two ways to install `asapdiscovery`:
 
 1. From conda-forge (recommended)
-2. Use the provided Docker image
-3. Developer installation from source
+2. Developer installation from source
 
 Installation from conda-forge
 ----------------------------
@@ -24,31 +23,13 @@ mamba install -c openeye openeye-toolkits
 
 ```
 
-Installation from Docker
-------------------------
-
-A Docker image is available for `asapdiscovery` on the Github container registry [ghcr.io](https://github.com/choderalab/asapdiscovery/pkgs/container/asapdiscovery) You can pull the image using the following command:
-
-```bash
- docker pull ghcr.io/choderalab/asapdiscovery:main
-```
-
-Now you can run the image using the following command:
-
-```bash
-docker run -it ghcr.io/choderalab/asapdiscovery:main
-```
-
-Note that the Docker image assumes that your OpenEye license is located at `~/.OpenEye/oe_license.txt`. If your license is located elsewhere, you can mount it to the container using the `-v` flag and the relevant environment variables.
-
-
 Developer installation from source
 ----------------------------------
 
 To install `asapdiscovery` from source, you will need to clone the repository, setup a compatible environment with mamba (or conda) and install the package using `pip`. You can do this using the following commands:
 
 ```bash
-git clone git@github.com:choderalab/asapdiscovery.git
+git clone git@github.com:asapdiscovery/asapdiscovery.git
 cd asapdiscovery
 mamba env create -f devtools/conda-envs/asapdiscovery-ubuntu-latest.yml # chose relevant file for your platform
 mamba activate asapdiscovery

--- a/examples/ml_pipeline.md
+++ b/examples/ml_pipeline.md
@@ -162,7 +162,7 @@ make-docked-complexes \
 
 # Machine Learning
 Finally we can get into the ML. As of PR
-[#601](https://github.com/choderalab/asapdiscovery/pull/601/), the ML part of this
+[#601](https://github.com/asapdiscovery/asapdiscovery/pull/601/), the ML part of this
 pipeline has drastically changed to be (hopefully) way easier to use. In this guide
 I'll try to show how things can be done both with the new CLI and with the API.
 

--- a/examples/running_md_simulations.ipynb
+++ b/examples/running_md_simulations.ipynb
@@ -12,28 +12,7 @@
    "cell_type": "markdown",
    "id": "64f939ac-6f7a-4198-902c-00a655a10634",
    "metadata": {},
-   "source": [
-    "Running vanilla molecular dynamics (MD) simulations on protein-ligand complexes can provide information about the dynamics of a given ligand inside the binding site and can be used to assess the quality and stability of a proposed binding mode.\n",
-    "\n",
-    "Below we will demonstrate an example of running MD simulations on a protein ligand complex, following docking, using the asapdiscovery framework. \n",
-    "\n",
-    "We will be running this example on an ASAP target, the SARS-CoV-2 nsp3 Mac1 macrodomain; this removes ADP ribose from viral and host cell proteins. The removal of this post-translational modification reduces the inflammatory and antiviral responses to infection — facilitating replication. For more information on Mac1, follow this [link](https://asapdiscovery.notion.site/Targeting-Opportunity-SARS-CoV-2-nsp3-Mac1-macrodomain-47af24638b994e8ba786303ec743926e).\n",
-    "\n",
-    "### Required modules\n",
-    "To execute this example, the following asapdiscovery modules to be installed: \n",
-    "- `data`,\n",
-    "- `docking`,\n",
-    "- `modeling`\n",
-    "- `simulation`\n",
-    "  \n",
-    "To enable the visualization of the docking results, the following modules will also need to be installed:\n",
-    "- `dataviz`\n",
-    "- `spectrum`.\n",
-    "\n",
-    "**Note** this example requires users have an [OpenEye](https://www.eyesopen.com/) license.\n",
-    "\n",
-    "Please refer to the [installation instructions](https://github.com/choderalab/asapdiscovery?tab=readme-ov-file#installation) for more details.  "
-   ]
+   "source": "Running vanilla molecular dynamics (MD) simulations on protein-ligand complexes can provide information about the dynamics of a given ligand inside the binding site and can be used to assess the quality and stability of a proposed binding mode.\n\nBelow we will demonstrate an example of running MD simulations on a protein ligand complex, following docking, using the asapdiscovery framework. \n\nWe will be running this example on an ASAP target, the SARS-CoV-2 nsp3 Mac1 macrodomain; this removes ADP ribose from viral and host cell proteins. The removal of this post-translational modification reduces the inflammatory and antiviral responses to infection — facilitating replication. For more information on Mac1, follow this [link](https://asapdiscovery.notion.site/Targeting-Opportunity-SARS-CoV-2-nsp3-Mac1-macrodomain-47af24638b994e8ba786303ec743926e).\n\n### Required modules\nTo execute this example, the following asapdiscovery modules to be installed: \n- `data`,\n- `docking`,\n- `modeling`\n- `simulation`\n  \nTo enable the visualization of the docking results, the following modules will also need to be installed:\n- `dataviz`\n- `spectrum`.\n\n**Note** this example requires users have an [OpenEye](https://www.eyesopen.com/) license.\n\nPlease refer to the [installation instructions](https://github.com/asapdiscovery/asapdiscovery?tab=readme-ov-file#installation) for more details.  "
   },
   {
    "cell_type": "code",
@@ -197,10 +176,7 @@
    "cell_type": "markdown",
    "id": "41c84958-6fa9-4d1d-8b85-972402cd0e12",
    "metadata": {},
-   "source": [
-    "## Vizualise the docked pose\n",
-    "Let us now vizualise our results! For more information on vizualisations, see the vizualisation notebook hosted in the [examples directory](https://github.com/choderalab/asapdiscovery/tree/main/examples)."
-   ]
+   "source": "## Vizualise the docked pose\nLet us now vizualise our results! For more information on vizualisations, see the vizualisation notebook hosted in the [examples directory](https://github.com/asapdiscovery/asapdiscovery/tree/main/examples)."
   },
   {
    "cell_type": "code",

--- a/examples/running_md_simulations.ipynb
+++ b/examples/running_md_simulations.ipynb
@@ -12,7 +12,28 @@
    "cell_type": "markdown",
    "id": "64f939ac-6f7a-4198-902c-00a655a10634",
    "metadata": {},
-   "source": "Running vanilla molecular dynamics (MD) simulations on protein-ligand complexes can provide information about the dynamics of a given ligand inside the binding site and can be used to assess the quality and stability of a proposed binding mode.\n\nBelow we will demonstrate an example of running MD simulations on a protein ligand complex, following docking, using the asapdiscovery framework. \n\nWe will be running this example on an ASAP target, the SARS-CoV-2 nsp3 Mac1 macrodomain; this removes ADP ribose from viral and host cell proteins. The removal of this post-translational modification reduces the inflammatory and antiviral responses to infection — facilitating replication. For more information on Mac1, follow this [link](https://asapdiscovery.notion.site/Targeting-Opportunity-SARS-CoV-2-nsp3-Mac1-macrodomain-47af24638b994e8ba786303ec743926e).\n\n### Required modules\nTo execute this example, the following asapdiscovery modules to be installed: \n- `data`,\n- `docking`,\n- `modeling`\n- `simulation`\n  \nTo enable the visualization of the docking results, the following modules will also need to be installed:\n- `dataviz`\n- `spectrum`.\n\n**Note** this example requires users have an [OpenEye](https://www.eyesopen.com/) license.\n\nPlease refer to the [installation instructions](https://github.com/asapdiscovery/asapdiscovery?tab=readme-ov-file#installation) for more details.  "
+   "source": [
+    "Running vanilla molecular dynamics (MD) simulations on protein-ligand complexes can provide information about the dynamics of a given ligand inside the binding site and can be used to assess the quality and stability of a proposed binding mode.\n",
+    "\n",
+    "Below we will demonstrate an example of running MD simulations on a protein ligand complex, following docking, using the asapdiscovery framework. \n",
+    "\n",
+    "We will be running this example on an ASAP target, the SARS-CoV-2 nsp3 Mac1 macrodomain; this removes ADP ribose from viral and host cell proteins. The removal of this post-translational modification reduces the inflammatory and antiviral responses to infection — facilitating replication. For more information on Mac1, follow this [link](https://asapdiscovery.notion.site/Targeting-Opportunity-SARS-CoV-2-nsp3-Mac1-macrodomain-47af24638b994e8ba786303ec743926e).\n",
+    "\n",
+    "### Required modules\n",
+    "To execute this example, the following asapdiscovery modules to be installed: \n",
+    "- `data`,\n",
+    "- `docking`,\n",
+    "- `modeling`\n",
+    "- `simulation`\n",
+    "  \n",
+    "To enable the visualization of the docking results, the following modules will also need to be installed:\n",
+    "- `dataviz`\n",
+    "- `spectrum`.\n",
+    "\n",
+    "**Note** this example requires users have an [OpenEye](https://www.eyesopen.com/) license.\n",
+    "\n",
+    "Please refer to the [installation instructions](https://github.com/asapdiscovery/asapdiscovery?tab=readme-ov-file#installation) for more details.  "
+   ]
   },
   {
    "cell_type": "code",
@@ -176,7 +197,10 @@
    "cell_type": "markdown",
    "id": "41c84958-6fa9-4d1d-8b85-972402cd0e12",
    "metadata": {},
-   "source": "## Vizualise the docked pose\nLet us now vizualise our results! For more information on vizualisations, see the vizualisation notebook hosted in the [examples directory](https://github.com/asapdiscovery/asapdiscovery/tree/main/examples)."
+   "source": [
+    "## Vizualise the docked pose\n",
+    "Let us now vizualise our results! For more information on vizualisations, see the vizualisation notebook hosted in the [examples directory](https://github.com/asapdiscovery/asapdiscovery/tree/main/examples)."
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Description

Follow-up to #1298. Sweeps every remaining `choderalab/asapdiscovery` reference in the repo after the ownership transfer to `asapdiscovery/`, and removes the Docker install section from the docs since the underlying workflow no longer exists.

### Repo ownership sweep

Most references have been working via GitHub's rename-redirect, but two were functionally broken:

- **README.md badges** — the codecov and pre-commit.ci badge URLs key on the canonical owner/repo, so the README was either showing stale data from the retired project or nothing at all. Switching to `asapdiscovery/asapdiscovery` makes them match the repo that's actually being uploaded to (now that #1298 re-enabled codecov uploads).

Everything else is just cosmetic cleanup:
- 10 × subpackage `pyproject.toml` — `Homepage` and `Bug Tracker`
- `docs/conf.py`, `docs/installation.md` — clone and source-tree URLs
- `.github/PULL_REQUEST_TEMPLATE.md` — LICENSE link
- `examples/ml_pipeline.md`, `examples/running_md_simulations.ipynb` — narrative links
- Two code-comment PR permalinks in `pose_generation.py` and `modeling/schema.py`

### Docker install docs removal

`docs/installation.md` advertised `docker pull ghcr.io/choderalab/asapdiscovery:main` as one of three install methods. #1298 deleted the workflow that built those images (and its Dockerfile), so those images will no longer receive updates. Rather than point docs at a decaying image, removed the whole Docker section — it can come back if/when someone sets up a replacement.

Net effect on the install list: three ways → two ways (conda-forge, from source).

## Out of scope

- ~~`docs/installation.md` still references `devtools/conda-envs/asapdiscovery-ubuntu-latest.yml` on line 34, which doesn't exist after the per-subpackage env split. Separate doc-accuracy issue.~~
- Pre-existing flake8 F401 warnings in `asapdiscovery-modeling/asapdiscovery/modeling/schema.py` (unused `Optional`, `Union` imports) — confirmed these exist on `main` independently of this PR.

## Test plan
- [ ] README codecov badge renders and points to the `asapdiscovery/asapdiscovery` codecov project
- [ ] README pre-commit.ci badge renders and points to the `asapdiscovery/asapdiscovery` project
- [x] `docs/installation.md` renders cleanly (two-item list, no orphaned Docker references)
- [ ] Notebook still loads after the markdown cell edits

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/asapdiscovery/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).