### PR TITLE
Fix numpy 2 `numpy.bool` TypeError in MSELoss.step_loss

### DIFF
--- a/asapdiscovery-ml/asapdiscovery/ml/loss.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/loss.py
@@ -86,7 +86,7 @@ class MSELoss(TorchMSELoss):
         # r > 0 -> measurement is above thresh, want to count if pred < target
         mask = torch.tensor(
             [
-                1.0 if ((r == 0) or (r is None)) else ((r < 0) == (t < i))
+                1.0 if ((r == 0) or (r is None)) else float((r < 0) == (t < i))
                 for i, t, r in zip(
                     np.ravel(pred.detach().cpu()),
                     np.ravel(target.detach().cpu()),


### PR DESCRIPTION
## Summary
Fixes the macOS CI failures in `asapdiscovery-ml/.../test_ml_cli.py::test_build_and_train_*` (gat, schnet, e3nn, visnet, and the `_jitter` variants).

All of these use the `mse_step` loss, whose mask construction in `MSELoss.step_loss` builds a list mixing Python `float` (`1.0`) with the result of `(r < 0) == (t < i)`. Since `r`, `t`, `i` are numpy scalars from `np.ravel`, that comparison returns a `numpy.bool_`. Passing the mixed list to `torch.tensor([...])` raises:

```
TypeError: 'numpy.bool' object cannot be interpreted as an integer
```

Under numpy < 2 this was only a `DeprecationWarning`, so the tests passed on ubuntu CI (numpy 1.x) but failed on macOS CI (numpy 2.x).

## Fix
Cast the boolean comparison to a Python `float` so the mask list is homogeneous:

```diff
-                1.0 if ((r == 0) or (r is None)) else ((r < 0) == (t < i))
+                1.0 if ((r == 0) or (r is None)) else float((r < 0) == (t < i))
```

Verified to produce identical results on numpy 1.26.4 and 2.4.3.

## Notes
- Independent of #1305 (OpenConf pose generator); branched off `main`.
- Scoped to this single root cause. Related-but-latent numpy-2 fragility exists in `asapdiscovery-ml/.../dataset.py` index-type detection (`isinstance(idx[0], bool/int)` fails for numpy scalars) but is not triggered by these tests; left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)