### PR TITLE
Remove cinnabar numpy 2.x monkey-patch; bump openfe to 1.12; drop Perses

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
@@ -1,5 +1,4 @@
 import base64
-import contextlib
 import warnings
 from typing import Literal, Optional
 
@@ -18,30 +17,6 @@ from rdkit import Chem
 from rdkit.Chem import Draw
 
 from asapdiscovery.data.schema.ligand import Ligand
-
-
-@contextlib.contextmanager
-def _patch_numpy_normal_for_cinnabar():
-    """Monkey-patch np.random.normal to return scalars when size=1.
-
-    Works around cinnabar bootstrap_statistic incompatibility with numpy 2.x
-    where np.random.normal(size=1) returns a 1-element array that can't be
-    assigned to a scalar array element.
-    """
-    _orig = np.random.normal
-
-    def _compat(*args, **kwargs):
-        result = _orig(*args, **kwargs)
-        if isinstance(result, np.ndarray) and result.size == 1:
-            return result.item()
-        return result
-
-    np.random.normal = _compat
-    try:
-        yield
-    finally:
-        np.random.normal = _orig
-
 
 # run to enable plotting with bokeh
 panel.extension()
@@ -818,25 +793,24 @@ def create_absolute_report(dataframe: pd.DataFrame) -> panel.Column:
         )
         # calculate the bootstrapped stats using cinnabar
         stats_data = []
-        with _patch_numpy_normal_for_cinnabar():
-            for statistic in ["RMSE", "MUE", "R2", "rho"]:
-                s = stats.bootstrap_statistic(
-                    plotting_df["pIC50 (EXPT)"].to_numpy(),
-                    plotting_df["pIC50 (FECS)"].to_numpy(),
-                    plotting_df["uncertainty (pIC50) (EXPT)"].to_numpy(),
-                    plotting_df["uncertainty (pIC50) (FECS)"].to_numpy(),
-                    statistic=statistic,
-                    include_true_uncertainty=False,
-                    include_pred_uncertainty=False,
-                )
-                stats_data.append(
-                    {
-                        "Statistic": statistic,
-                        "value": s["mle"],
-                        "lower bound": s["low"],
-                        "upper bound": s["high"],
-                    }
-                )
+        for statistic in ["RMSE", "MUE", "R2", "rho"]:
+            s = stats.bootstrap_statistic(
+                plotting_df["pIC50 (EXPT)"].to_numpy(),
+                plotting_df["pIC50 (FECS)"].to_numpy(),
+                plotting_df["uncertainty (pIC50) (EXPT)"].to_numpy(),
+                plotting_df["uncertainty (pIC50) (FECS)"].to_numpy(),
+                statistic=statistic,
+                include_true_uncertainty=False,
+                include_pred_uncertainty=False,
+            )
+            stats_data.append(
+                {
+                    "Statistic": statistic,
+                    "value": s["mle"],
+                    "lower bound": s["low"],
+                    "upper bound": s["high"],
+                }
+            )
         stats_df = pd.DataFrame(stats_data)
         # create a format for numerical data in the tables
         stats_format = {col: number_format for col in stats_df.columns}
@@ -931,25 +905,24 @@ def create_relative_report(dataframe: pd.DataFrame) -> panel.Column:
         )
         # calculate the bootstrapped stats using cinnabar
         stats_data = []
-        with _patch_numpy_normal_for_cinnabar():
-            for statistic in ["RMSE", "MUE", "R2", "rho"]:
-                s = stats.bootstrap_statistic(
-                    plotting_df["DpIC50 (EXPT)"].to_numpy(),
-                    plotting_df["DpIC50 (FECS)"].to_numpy(),
-                    plotting_df["uncertainty (pIC50) (EXPT)"].to_numpy(),
-                    plotting_df["uncertainty (pIC50) (FECS)"].to_numpy(),
-                    statistic=statistic,
-                    include_true_uncertainty=False,
-                    include_pred_uncertainty=False,
-                )
-                stats_data.append(
-                    {
-                        "Statistic": statistic,
-                        "value": s["mle"],
-                        "lower bound": s["low"],
-                        "upper bound": s["high"],
-                    }
-                )
+        for statistic in ["RMSE", "MUE", "R2", "rho"]:
+            s = stats.bootstrap_statistic(
+                plotting_df["DpIC50 (EXPT)"].to_numpy(),
+                plotting_df["DpIC50 (FECS)"].to_numpy(),
+                plotting_df["uncertainty (pIC50) (EXPT)"].to_numpy(),
+                plotting_df["uncertainty (pIC50) (FECS)"].to_numpy(),
+                statistic=statistic,
+                include_true_uncertainty=False,
+                include_pred_uncertainty=False,
+            )
+            stats_data.append(
+                {
+                    "Statistic": statistic,
+                    "value": s["mle"],
+                    "lower bound": s["low"],
+                    "upper bound": s["high"],
+                }
+            )
         stats_df = pd.DataFrame(stats_data)
         # create a format for numerical data in the tables
         stats_format = {col: number_format for col in stats_df.columns}

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/atom_mapping.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/atom_mapping.py
@@ -74,46 +74,6 @@ class LomapAtomMapper(_BaseAtomMapper):
         }
 
 
-class PersesAtomMapper(_BaseAtomMapper):
-    """
-    A settings class for the PersesAtomMapper in openFE
-    """
-
-    type: Literal["PersesAtomMapper"] = "PersesAtomMapper"
-
-    allow_ring_breaking: bool = Field(
-        True, description="If only full cycles of the molecules should be mapped."
-    )
-    preserve_chirality: bool = Field(
-        True,
-        description="If mappings must strictly preserve the chirality of the molecules.",
-    )
-    use_positions: bool = Field(
-        True,
-        description="If 3D positions should be used during the generation of the mappings.",
-    )
-    coordinate_tolerance: PositiveFloat = Field(
-        0.25,
-        description="A tolerance on how close coordinates need to be in Angstroms before they can be mapped. Does nothing if use_positions is `False`.",
-    )
-
-    def _get_mapper(self):
-        from openfe import PersesAtomMapper
-
-        return PersesAtomMapper(**self.model_dump(exclude={"type"}))
-
-    def provenance(self) -> dict[str, str]:
-        import openeye.oechem
-        import openfe
-        import perses
-
-        return {
-            "openfe": openfe.__version__,
-            "perses": perses.__version__,
-            "openeye.oechem": openeye.oechem.OEChemGetVersion(),
-        }
-
-
 class KartografAtomMapper(_BaseAtomMapper):
     """
     A settings class for the kartograf atom mapping method.

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/atom_mapping.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/atom_mapping.py
@@ -114,12 +114,13 @@ class KartografAtomMapper(_BaseAtomMapper):
         return KartografAtomMapper(**settings)
 
     def provenance(self) -> dict[str, str]:
-        import kartograf._version
+        from importlib.metadata import version
+
         import openfe
         import rdkit
 
         return {
             "openfe": openfe.__version__,
             "rdkit": rdkit.__version__,
-            "kartograf": kartograf._version.__version__,
+            "kartograf": version("kartograf"),
         }

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
@@ -13,7 +13,7 @@ from gufe.settings.typing import (
     specify_quantity_units,
 )
 from gufe.tokenization import JSON_HANDLER, GufeKey
-from openfe.setup.atom_mapping import lomap_scorers, perses_scorers
+from openfe.setup.atom_mapping import lomap_scorers
 from openff.units import unit as OFFUnit
 from pydantic import (
     ConfigDict,
@@ -133,11 +133,9 @@ class AdaptiveSettings(_SchemaBase):
         """
         if scorer_method == "default_lomap":
             scorer = lomap_scorers.default_lomap_score
-        elif scorer_method == "default_perses":
-            scorer = perses_scorers.default_perses_scorer
         else:
             raise ValueError(
-                f"Atom mapping scorer {scorer_method} not recognized; use one of `default_lomap`, `default_perses`."
+                f"Atom mapping scorer {scorer_method} not recognized; use `default_lomap`."
             )
         if scorer(mapping) < self.adaptive_sampling_threshold:
             settings.simulation_settings.production_length = (

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/network.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/network.py
@@ -8,7 +8,7 @@ from pydantic import ConfigDict, Field
 from asapdiscovery.data.schema.ligand import Ligand
 
 from ._util import check_ligand_series_uniqueness_and_names
-from .atom_mapping import KartografAtomMapper, LomapAtomMapper, PersesAtomMapper
+from .atom_mapping import KartografAtomMapper, LomapAtomMapper
 from .base import _SchemaBase
 
 
@@ -103,13 +103,11 @@ class _NetworkPlannerSettings(_SchemaBase):
 
     type: Literal["NetworkPlanner"] = "NetworkPlanner"
 
-    atom_mapping_engine: Union[
-        LomapAtomMapper, PersesAtomMapper, KartografAtomMapper
-    ] = Field(
+    atom_mapping_engine: Union[LomapAtomMapper, KartografAtomMapper] = Field(
         LomapAtomMapper(),
         description="The method which should be used to create the mappings between molecules in the FEC network.",
     )
-    scorer: Literal["default_lomap", "default_perses"] = Field(
+    scorer: Literal["default_lomap"] = Field(
         "default_lomap",
         description="The method which should be used to score the proposed atom mappings by the atom mapping engine.",
     )
@@ -208,11 +206,8 @@ class NetworkPlanner(_NetworkPlannerSettings):
     type: Literal["NetworkPlanner"] = "NetworkPlanner"
 
     def _get_scorer(self):
-        # We don't need to explicitly handle raising an error as pydantic validation will do it for us
-        if self.scorer == "default_lomap":
-            return openfe.lomap_scorers.default_lomap_score
-        else:
-            return openfe.perses_scorers.default_perses_scorer
+        # Only default_lomap is supported; pydantic validation enforces the scorer value
+        return openfe.lomap_scorers.default_lomap_score
 
     def generate_network(
         self,

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
@@ -9,7 +9,6 @@ from openff.units import unit as OFFUnit
 from asapdiscovery.alchemy.schema.atom_mapping import (
     KartografAtomMapper,
     LomapAtomMapper,
-    PersesAtomMapper,
 )
 from asapdiscovery.alchemy.schema.fec import (
     AdaptiveSettings,
@@ -36,13 +35,6 @@ from asapdiscovery.data.schema.identifiers import BespokeParameter, BespokeParam
     [
         pytest.param(LomapAtomMapper, "max3d", 30, id="Lomap"),
         pytest.param(
-            PersesAtomMapper,
-            "coordinate_tolerance",
-            0.15,
-            id="Perses",
-            marks=pytest.mark.xfail(reason="upstream OpenFE #929"),
-        ),
-        pytest.param(
             KartografAtomMapper, "map_exact_ring_matches_only", True, id="Kartograph"
         ),
     ],
@@ -68,9 +60,6 @@ def test_lomap_atom_mapper_timeout():
     "mapper, programs",
     [
         pytest.param(LomapAtomMapper, ["openfe", "lomap", "rdkit"], id="Lomap"),
-        pytest.param(
-            PersesAtomMapper, ["openfe", "perses", "openeye.oechem"], id="Perses"
-        ),
         pytest.param(
             KartografAtomMapper, ["openfe", "rdkit", "kartograf"], id="Kartograph"
         ),
@@ -123,7 +112,6 @@ def test_plan_from_names(tyk2_ligands, tyk2_small_custom_network):
     "scorer",
     [
         pytest.param("default_lomap", id="Lomap"),
-        pytest.param("default_perses", id="Perses"),
     ],
 )
 def test_network_planner_get_scorer(scorer):
@@ -210,10 +198,11 @@ def test_planner_file_round_trip(tmpdir):
     with tmpdir.as_cwd():
         # configure with non default settings
         filename = "network_planner.json"
-        planner = NetworkPlanner(scorer="default_perses")
+        planner = NetworkPlanner(atom_mapping_engine=KartografAtomMapper())
         planner.to_file(filename=filename)
         planner_2 = NetworkPlanner.from_file(filename=filename)
         assert planner.scorer == planner_2.scorer
+        assert planner.atom_mapping_engine.type == planner_2.atom_mapping_engine.type
 
 
 def test_fec_to_openfe_protocols():

--- a/devtools/conda-envs/macos-latest/alchemy.yaml
+++ b/devtools/conda-envs/macos-latest/alchemy.yaml
@@ -28,7 +28,7 @@ dependencies:
   - pebble
   - rdkit
   - openff-toolkit =0.18.0
-  - openff-interchange =0.4.11
+  - openff-interchange >=0.5.0,!=0.5.1
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
   - multimethod
@@ -53,8 +53,8 @@ dependencies:
   - netifaces
 
   # Alchemy / Free energy
-  - openfe =1.8.0
-  - gufe =1.7.1
+  - openfe =1.12.0
+  - gufe =1.12.0
   - openmm =8.2.0
   - openmmforcefields =0.15.1
   - mdtraj
@@ -63,7 +63,7 @@ dependencies:
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2
-  - feflow =0.2.0
+  - feflow =0.2.1
   - cinnabar >=0.6.0
   - seaborn
   - panel

--- a/devtools/conda-envs/macos-latest/alchemy.yaml
+++ b/devtools/conda-envs/macos-latest/alchemy.yaml
@@ -64,7 +64,7 @@ dependencies:
   - rich
   - alchemiscale-client >=0.7.2
   - feflow =0.2.0
-  - cinnabar >=0.4.1
+  - cinnabar >=0.6.0
   - seaborn
   - panel
   - plotmol

--- a/devtools/conda-envs/macos-latest/alchemy.yaml
+++ b/devtools/conda-envs/macos-latest/alchemy.yaml
@@ -59,7 +59,6 @@ dependencies:
   - openmmforcefields =0.15.1
   - mdtraj
   - httpx
-  - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2

--- a/devtools/conda-envs/macos-latest/all.yaml
+++ b/devtools/conda-envs/macos-latest/all.yaml
@@ -85,7 +85,7 @@ dependencies:
   - rich
   - alchemiscale-client >=0.7.2
   - feflow =0.2.0
-  - cinnabar >=0.4.1
+  - cinnabar >=0.6.0
 
   # Visualization
   - seaborn

--- a/devtools/conda-envs/macos-latest/all.yaml
+++ b/devtools/conda-envs/macos-latest/all.yaml
@@ -80,7 +80,6 @@ dependencies:
   - openfe =1.12.0
   - gufe =1.12.0
   - httpx
-  - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2

--- a/devtools/conda-envs/macos-latest/all.yaml
+++ b/devtools/conda-envs/macos-latest/all.yaml
@@ -27,7 +27,7 @@ dependencies:
   - pebble
   - rdkit
   - openff-toolkit =0.18.0
-  - openff-interchange =0.4.11
+  - openff-interchange >=0.5.0,!=0.5.1
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
@@ -77,14 +77,14 @@ dependencies:
   - mdanalysis
 
   # Alchemy / Free energy
-  - openfe =1.8.0
-  - gufe =1.7.1
+  - openfe =1.12.0
+  - gufe =1.12.0
   - httpx
   - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2
-  - feflow =0.2.0
+  - feflow =0.2.1
   - cinnabar >=0.6.0
 
   # Visualization

--- a/devtools/conda-envs/macos-latest/cli.yaml
+++ b/devtools/conda-envs/macos-latest/cli.yaml
@@ -78,7 +78,6 @@ dependencies:
   - openfe =1.12.0
   - gufe =1.12.0
   - httpx
-  - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2

--- a/devtools/conda-envs/macos-latest/cli.yaml
+++ b/devtools/conda-envs/macos-latest/cli.yaml
@@ -27,7 +27,7 @@ dependencies:
   - pebble
   - rdkit
   - openff-toolkit =0.18.0
-  - openff-interchange =0.4.11
+  - openff-interchange >=0.5.0,!=0.5.1
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
   - multimethod
@@ -75,14 +75,14 @@ dependencies:
   - mdanalysis
 
   # Alchemy / Free energy
-  - openfe =1.8.0
-  - gufe =1.7.1
+  - openfe =1.12.0
+  - gufe =1.12.0
   - httpx
   - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2
-  - feflow =0.2.0
+  - feflow =0.2.1
   - cinnabar >=0.6.0
 
   # Visualization

--- a/devtools/conda-envs/macos-latest/cli.yaml
+++ b/devtools/conda-envs/macos-latest/cli.yaml
@@ -83,7 +83,7 @@ dependencies:
   - rich
   - alchemiscale-client >=0.7.2
   - feflow =0.2.0
-  - cinnabar >=0.4.1
+  - cinnabar >=0.6.0
 
   # Visualization
   - seaborn

--- a/devtools/conda-envs/ubuntu-latest/alchemy.yaml
+++ b/devtools/conda-envs/ubuntu-latest/alchemy.yaml
@@ -28,7 +28,7 @@ dependencies:
   - pebble
   - rdkit
   - openff-toolkit =0.18.0
-  - openff-interchange =0.4.11
+  - openff-interchange >=0.5.0,!=0.5.1
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
@@ -58,8 +58,8 @@ dependencies:
   - mafft
 
   # Alchemy / Free energy
-  - openfe =1.8.0
-  - gufe =1.7.1
+  - openfe =1.12.0
+  - gufe =1.12.0
   - openmm =8.2.0
   - openmmforcefields =0.15.1
   - mdtraj
@@ -68,7 +68,7 @@ dependencies:
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2
-  - feflow =0.2.0
+  - feflow =0.2.1
   - cinnabar >=0.6.0
   - seaborn
   - panel

--- a/devtools/conda-envs/ubuntu-latest/alchemy.yaml
+++ b/devtools/conda-envs/ubuntu-latest/alchemy.yaml
@@ -69,7 +69,7 @@ dependencies:
   - rich
   - alchemiscale-client >=0.7.2
   - feflow =0.2.0
-  - cinnabar >=0.4.1
+  - cinnabar >=0.6.0
   - seaborn
   - panel
   - plotmol

--- a/devtools/conda-envs/ubuntu-latest/alchemy.yaml
+++ b/devtools/conda-envs/ubuntu-latest/alchemy.yaml
@@ -64,7 +64,6 @@ dependencies:
   - openmmforcefields =0.15.1
   - mdtraj
   - httpx
-  - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2

--- a/devtools/conda-envs/ubuntu-latest/all.yaml
+++ b/devtools/conda-envs/ubuntu-latest/all.yaml
@@ -89,7 +89,7 @@ dependencies:
   - rich
   - alchemiscale-client >=0.7.2
   - feflow =0.2.0
-  - cinnabar >=0.4.1
+  - cinnabar >=0.6.0
 
   # Visualization
   - seaborn

--- a/devtools/conda-envs/ubuntu-latest/all.yaml
+++ b/devtools/conda-envs/ubuntu-latest/all.yaml
@@ -27,7 +27,7 @@ dependencies:
   - pebble    # remove?
   - rdkit
   - openff-toolkit =0.18.0
-  - openff-interchange =0.4.11
+  - openff-interchange >=0.5.0,!=0.5.1
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
@@ -81,14 +81,14 @@ dependencies:
   - mdanalysis
 
   # Alchemy / Free energy
-  - openfe =1.8.0
-  - gufe =1.7.1
+  - openfe =1.12.0
+  - gufe =1.12.0
   - httpx
   - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2
-  - feflow =0.2.0
+  - feflow =0.2.1
   - cinnabar >=0.6.0
 
   # Visualization

--- a/devtools/conda-envs/ubuntu-latest/all.yaml
+++ b/devtools/conda-envs/ubuntu-latest/all.yaml
@@ -84,7 +84,6 @@ dependencies:
   - openfe =1.12.0
   - gufe =1.12.0
   - httpx
-  - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2

--- a/devtools/conda-envs/ubuntu-latest/cli.yaml
+++ b/devtools/conda-envs/ubuntu-latest/cli.yaml
@@ -90,7 +90,7 @@ dependencies:
   - rich
   - alchemiscale-client >=0.7.2
   - feflow =0.2.0
-  - cinnabar >=0.4.1
+  - cinnabar >=0.6.0
 
   # Visualization
   - seaborn

--- a/devtools/conda-envs/ubuntu-latest/cli.yaml
+++ b/devtools/conda-envs/ubuntu-latest/cli.yaml
@@ -27,7 +27,7 @@ dependencies:
   - pebble
   - rdkit
   - openff-toolkit =0.18.0
-  - openff-interchange =0.4.11
+  - openff-interchange >=0.5.0,!=0.5.1
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
@@ -82,14 +82,14 @@ dependencies:
   - mdanalysis
 
   # Alchemy / Free energy
-  - openfe =1.8.0
-  - gufe =1.7.1
+  - openfe =1.12.0
+  - gufe =1.12.0
   - httpx
   - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2
-  - feflow =0.2.0
+  - feflow =0.2.1
   - cinnabar >=0.6.0
 
   # Visualization

--- a/devtools/conda-envs/ubuntu-latest/cli.yaml
+++ b/devtools/conda-envs/ubuntu-latest/cli.yaml
@@ -85,7 +85,6 @@ dependencies:
   - openfe =1.12.0
   - gufe =1.12.0
   - httpx
-  - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client >=0.7.2

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -103,7 +103,6 @@ dependencies:
   - openfe =>0.14.0
   - gufe =>0.9.5
   - httpx
-  - perses >=0.10.2
   - kartograf
   - rich
   - alchemiscale-client

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -107,7 +107,7 @@ dependencies:
   - kartograf
   - rich
   - alchemiscale-client
-  - cinnabar >=0.4.1
+  - cinnabar >=0.6.0
 
 
 

--- a/examples/running_alchemical_free_energy_calculations.ipynb
+++ b/examples/running_alchemical_free_energy_calculations.ipynb
@@ -11189,7 +11189,6 @@
     "    NetworkPlanner, \n",
     "    KartografAtomMapper, \n",
     "    LomapAtomMapper, \n",
-    "    PersesAtomMapper, \n",
     "    RadialPlanner,\n",
     "    MaximalPlanner, \n",
     "    MinimalRedundantPlanner, \n",
@@ -11225,7 +11224,7 @@
    "source": [
     "### Atom Mapping Engine\n",
     "\n",
-    "Our free energy calculations by default use a hybrid topology approach and so an atom mapping which identifies the atoms of ligand A which should be alchemicaly transformed to atoms of ligand B is needed. Atoms that are not mapped should be consistend between ligands A/B. We currently support all of the available OpenFE atom mappers (LomapAtomMapper, PersesAtomMapper & KartografAtomMapper) but use Lomap by default which can be constructed as follows:"
+    "Our free energy calculations by default use a hybrid topology approach and so an atom mapping which identifies the atoms of ligand A which should be alchemicaly transformed to atoms of ligand B is needed. Atoms that are not mapped should be consistend between ligands A/B. We currently support all of the available OpenFE atom mappers (LomapAtomMapper & KartografAtomMapper) but use Lomap by default which can be constructed as follows:"
    ]
   },
   {


### PR DESCRIPTION
Closes #1294. Resolves #1317.

## Why this grew beyond a one-line patch removal
Removing the cinnabar numpy 2.x monkey-patch (#1294) requires cinnabar >=0.6.0 (the first release with the upstream `bootstrap_statistic` fix). But cinnabar 0.6.0 is only installable with **openfe 1.12.0** (openfe 1.8.0 caps `cinnabar <0.6.0`), and **openfe 1.12.0 removed Perses atom mapping entirely**. So the three changes are inseparable.

## Changes
**1. Remove the cinnabar workaround (#1294)**
- Delete `_patch_numpy_normal_for_cinnabar()` + the two `with` blocks in `alchemy/predict.py`; drop the unused `contextlib` import.

**2. Bump the FE stack so the fixed cinnabar installs**
- `openfe 1.8.0 → 1.12.0`, `gufe 1.7.1 → 1.12.0`, `feflow 0.2.0 → 0.2.1`, `openff-interchange =0.4.11 → >=0.5.0,!=0.5.1`, `cinnabar >=0.4.1 → >=0.6.0`, across the alchemy/cli/all envs (+ docs). pydantic is already `>2`.

**3. Remove Perses atom mapper/scorer support (#1317)** — required because openfe 1.12 deleted it
- Delete the `PersesAtomMapper` settings class; drop it from the `atom_mapping_engine` union and `"default_perses"` from the `scorer` Literal; remove the `perses_scorers` import and `default_perses` branch; update tests; drop the `perses` dependency from envs/docs; update the example notebook.

## Verification
- `python -m py_compile` passes on all changed modules; repo-wide grep confirms zero remaining `perses`/`cinnabar`-patch references.
- Environment now solves on CI (previously failed on the cinnabar conflict); alchemy tests exercised via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)