### PR TITLE
Allow `asap-alchemy restart` to take a network ScopedKey

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -722,6 +722,16 @@ def status(
     help="The name of the JSON file containing a planned FEC network.",
     default="planned_network.json",
     show_default=True,
+    required=False,
+)
+@click.option(
+    "-nk",
+    "--network_key",
+    type=click.STRING,
+    help="The network key of the network whose errored Tasks should be restarted. "
+    "Used in preference to --network; find it by running e.g. `asap-alchemy status -a`.",
+    default=None,
+    required=False,
 )
 @click.option(
     "-v",
@@ -733,8 +743,11 @@ def status(
     "tasks",
     nargs=-1,
 )
-def restart(network: str, verbose: bool, tasks):
+def restart(network: str, network_key: str, verbose: bool, tasks):
     """Restart errored Tasks for the given FEC network.
+
+    The network can be specified either by a planned network JSON file
+    (-n/--network) or directly by its ScopedKey (-nk/--network_key).
 
     If TASKS specified, then only these will be restarted.
 
@@ -745,11 +758,33 @@ def restart(network: str, verbose: bool, tasks):
     from asapdiscovery.alchemy.utils import AlchemiscaleHelper
 
     client = AlchemiscaleHelper.from_settings()
-    planned_network = FreeEnergyCalculationNetwork.from_file(network)
+
+    if network_key:
+        if Path(network).exists():
+            click.echo(
+                f"Network key provided: {network_key}, prefering over network file {network}."
+            )
+    else:
+        click.echo(f"Network file provided: {network}, loading network.")
+        if not Path(network).exists():
+            raise FileNotFoundError(f"Network file {network} does not exist.")
+        planned_network = FreeEnergyCalculationNetwork.from_file(network)
+        network_key = planned_network.results.network_key
+
+    # confirm the network exists before attempting to restart its tasks
+    try:
+        if not client.network_exists(network_key=network_key):
+            raise ValueError(
+                f"Network key {network_key} does not exist in Alchemiscale."
+            )
+    except Exception as e:
+        raise ValueError(
+            f"Network key {network_key} does not exist in Alchemiscale."
+        ) from e
 
     tasks = [ScopedKey.from_str(task) for task in tasks]
 
-    restarted_tasks = client.restart_tasks(planned_network, tasks)
+    restarted_tasks = client.restart_tasks(network_key=network_key, tasks=tasks)
     if verbose:
         click.echo(f"Restarted Tasks: {[str(i) for i in restarted_tasks]}")
     else:

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -471,7 +471,7 @@ def gather(
     if network_key:
         if Path(network).exists():
             click.echo(
-                f"Network key provided: {network_key}, prefering over network file {network}."
+                f"Network key provided: {network_key}, preferring over network file {network}."
             )
         using_network_key = True
     else:
@@ -673,7 +673,7 @@ def status(
         if network_key:
             if Path(network).exists():
                 click.echo(
-                    f"Network key provided: {network_key}, prefering over network file {network}."
+                    f"Network key provided: {network_key}, preferring over network file {network}."
                 )
 
         else:
@@ -762,7 +762,7 @@ def restart(network: str, network_key: str, verbose: bool, tasks):
     if network_key:
         if Path(network).exists():
             click.echo(
-                f"Network key provided: {network_key}, prefering over network file {network}."
+                f"Network key provided: {network_key}, preferring over network file {network}."
             )
     else:
         click.echo(f"Network file provided: {network}, loading network.")

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
@@ -709,6 +709,51 @@ def test_alchemy_stop_hard(monkeypatch):
     )
 
 
+def test_alchemy_restart_network_key(monkeypatch):
+    """Test restarting errored tasks on a network identified by its ScopedKey,
+    without needing a planned_network.json file."""
+    monkeypatch.setenv("ALCHEMISCALE_ID", "my-id")
+    monkeypatch.setenv("ALCHEMISCALE_KEY", "my-key")
+
+    runner = CliRunner()
+
+    network_key = ScopedKey(
+        gufe_key="fakenetwork-12345",
+        org="asap",
+        campaign="alchemy",
+        project="testing",
+    )
+    errored_tasks = [
+        ScopedKey(
+            gufe_key=f"task-{i}",
+            org="asap",
+            campaign="alchemy",
+            project="testing",
+        )
+        for i in range(3)
+    ]
+
+    def check_exists(*args, **kwargs):
+        return True
+
+    def get_network_tasks(self, network, status=None):
+        assert ScopedKey.from_str(network) == network_key
+        assert status == "error"
+        return errored_tasks
+
+    def set_tasks_status(self, tasks, status=None):
+        assert status == "waiting"
+        return tasks
+
+    monkeypatch.setattr(AlchemiscaleClient, "check_exists", check_exists)
+    monkeypatch.setattr(AlchemiscaleClient, "get_network_tasks", get_network_tasks)
+    monkeypatch.setattr(AlchemiscaleClient, "set_tasks_status", set_tasks_status)
+
+    result = runner.invoke(alchemy, ["restart", "-nk", network_key])
+    assert click_success(result)
+    assert "Restarted 3 Tasks" in result.stdout
+
+
 def test_submit_bad_campaign(tyk2_fec_network, tmpdir):
     """Make sure an error is raised if the org is asap but the campaign is not in public or confidential."""
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -192,20 +192,31 @@ class AlchemiscaleHelper:
 
     def restart_tasks(
         self,
-        planned_network: FreeEnergyCalculationNetwork,
+        planned_network: Optional[FreeEnergyCalculationNetwork] = None,
         tasks: Optional[list[ScopedKey]] = None,
+        network_key: Optional[str] = None,
     ) -> list[ScopedKey]:
         """
         Restart errored tasks on alchemiscale for this network.
 
+        The network can be identified either by passing a `planned_network` or
+        directly by its `network_key`. If both are given, `network_key` is used.
+
         Args:
             planned_network: The network which we should look up in alchemiscale.
             tasks: ScopedKeys to limit restarts to; if empty, then all errored tasks restarted.
+            network_key: The ScopedKey of the network to restart tasks for; used in
+                preference to `planned_network`.
 
         Returns:
             list of ScopedKeys for the tasks that were restarted
         """
-        network_key = planned_network.results.network_key
+        if network_key is None:
+            if planned_network is None:
+                raise ValueError(
+                    "One of `planned_network` or `network_key` must be provided."
+                )
+            network_key = planned_network.results.network_key
         errored_tasks = self._client.get_network_tasks(network_key, status="error")
 
         if tasks:


### PR DESCRIPTION
Closes #1306.

`asap-alchemy restart` previously required a full `planned_network.json`, but restarting errored Tasks only needs the network's ScopedKey. This mirrors the existing `status`/`gather` dual-input pattern so the network can be identified either way.

## Changes
- Add `-nk/--network_key` to the `restart` command; `-n/--network` is now `required=False`. When both are given, the key is preferred (matching `status`). The key is validated with `network_exists` before restarting.
- Generalize `AlchemiscaleHelper.restart_tasks` to accept a `network_key` directly (in preference to `planned_network`), matching `collect_results`. Backward compatible — existing `planned_network=` callers/tests still work.
- Add `test_alchemy_restart_network_key` exercising the key-only path (no network file needed).

## Usage
```
asap-alchemy restart -nk <network-scoped-key>          # restart all errored tasks
asap-alchemy restart -nk <network-scoped-key> <task-sk>...   # restart specific tasks
asap-alchemy restart -n planned_network.json           # still works
```

## Verification
- `python -m py_compile` passes on all modified files.
- Added CLI test mocks `check_exists`/`get_network_tasks`/`set_tasks_status` and asserts the key-only invocation restarts the errored tasks. (Full test suite requires the conda env; validated by CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)