### PR TITLE
Move DockingResultCols enum from docking to data package

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/schema/docking_data_validation.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/docking_data_validation.py
@@ -1,0 +1,30 @@
+from enum import Enum
+
+
+class DockingResultCols(str, Enum):
+    DOCKING_CONFIDENCE_POSIT = "docking-confidence-POSIT"  # postera
+    DOCKING_SCORE_POSIT = "docking-score-POSIT"  # postera
+    DOCKING_STRUCTURE_POSIT = "docking-structure-POSIT"  # postera
+    FITNESS_SCORE_FINT = "fitness-score-FINT"  # postera
+    DOCKING_HIT = "docking-hit"  # postera
+    SMILES = "SMILES"  # postera
+    INCHIKEY = "INCHIKEY"  # postera
+    COMPUTED_GAT_PIC50 = "computed-GAT-pIC50"  # postera
+    COMPUTED_SCHNET_PIC50 = "computed-SchNet-pIC50"  # postera
+    COMPUTED_E3NN_PIC50 = "computed-E3NN-pIC50"  # postera
+    COMPUTED_GAT_LOGD = "computed-GAT-LogD"  # postera
+    POSIT_METHOD = "_POSIT_method"
+    LIGAND_ID = "ligand_id"
+    TARGET_ID = "target_id"
+    HTML_PATH_POSE = "html_path_pose"
+    HTML_PATH_FITNESS = "html_path_fitness"
+    GIF_PATH = "gif_path"
+    MD_PATH_TRAJ = "md_path_traj"
+    MD_PATH_MIN_PDB = "md_path_min_pdb"
+    MD_PATH_FINAL_PDB = "md_path_final_pdb"
+    SYMEXP_CLASHING = "symexp-clashing"  # postera
+    SYMEXP_CLASH_NUM = "symexp-clash-num"  # postera
+
+    @classmethod
+    def get_columns(cls) -> list[str]:
+        return [col.value for col in cls]

--- a/asapdiscovery-data/asapdiscovery/data/services/postera/manifold_artifacts.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/manifold_artifacts.py
@@ -19,7 +19,7 @@ from asapdiscovery.data.services.services_config import (
     PosteraSettings,
     S3Settings,
 )
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 
 
 class ArtifactType(Enum):

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
@@ -18,7 +18,7 @@ from asapdiscovery.dataviz._gif_blocks import GIFBlockData
 from asapdiscovery.dataviz.resources.fonts import opensans_regular
 from asapdiscovery.dataviz.show_contacts import show_contacts
 from asapdiscovery.dataviz.visualizer import VisualizerBase
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 from asapdiscovery.simulation.simulate import SimulationResult
 
 logger = logging.getLogger(__name__)

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
@@ -34,7 +34,7 @@ from asapdiscovery.data.util.logging import HiddenPrint
 from asapdiscovery.dataviz._html_blocks import HTMLBlockData
 from asapdiscovery.dataviz.visualizer import VisualizerBase
 from asapdiscovery.docking.docking import DockingResult
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 from asapdiscovery.modeling.modeling import superpose_molecule  # TODO: move to backend
 from asapdiscovery.spectrum.fitness import (
     _FITNESS_DATA_FIT_THRESHOLD,

--- a/asapdiscovery-docking/asapdiscovery/docking/docking_data_validation.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/docking_data_validation.py
@@ -1,31 +1,9 @@
-from enum import Enum
-from typing import List, Optional  # noqa: F401
-
-
-class DockingResultCols(str, Enum):
-    DOCKING_CONFIDENCE_POSIT = "docking-confidence-POSIT"  # postera
-    DOCKING_SCORE_POSIT = "docking-score-POSIT"  # postera
-    DOCKING_STRUCTURE_POSIT = "docking-structure-POSIT"  # postera
-    FITNESS_SCORE_FINT = "fitness-score-FINT"  # postera
-    DOCKING_HIT = "docking-hit"  # postera
-    SMILES = "SMILES"  # postera
-    INCHIKEY = "INCHIKEY"  # postera
-    COMPUTED_GAT_PIC50 = "computed-GAT-pIC50"  # postera
-    COMPUTED_SCHNET_PIC50 = "computed-SchNet-pIC50"  # postera
-    COMPUTED_E3NN_PIC50 = "computed-E3NN-pIC50"  # postera
-    COMPUTED_GAT_LOGD = "computed-GAT-LogD"  # postera
-    POSIT_METHOD = "_POSIT_method"
-    LIGAND_ID = "ligand_id"
-    TARGET_ID = "target_id"
-    HTML_PATH_POSE = "html_path_pose"
-    HTML_PATH_FITNESS = "html_path_fitness"
-    GIF_PATH = "gif_path"
-    MD_PATH_TRAJ = "md_path_traj"
-    MD_PATH_MIN_PDB = "md_path_min_pdb"
-    MD_PATH_FINAL_PDB = "md_path_final_pdb"
-    SYMEXP_CLASHING = "symexp-clashing"  # postera
-    SYMEXP_CLASH_NUM = "symexp-clash-num"  # postera
-
-    @classmethod
-    def get_columns(cls) -> list[str]:
-        return [col.value for col in cls]
+# Backwards-compatible re-export.
+#
+# ``DockingResultCols`` now lives in the ``asapdiscovery.data`` package so that
+# ``asapdiscovery.data`` no longer imports from ``asapdiscovery.docking`` at
+# runtime (``data`` is the dependency-free foundation package).
+# See https://github.com/asapdiscovery/asapdiscovery/issues/1292
+from asapdiscovery.data.schema.docking_data_validation import (  # noqa: F401
+    DockingResultCols,
+)

--- a/asapdiscovery-docking/asapdiscovery/docking/openeye.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/openeye.py
@@ -20,7 +20,7 @@ from asapdiscovery.docking.docking import (
     DockingInputPair,
     DockingResult,
 )
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 
 logger = logging.getLogger(__name__)
 

--- a/asapdiscovery-docking/asapdiscovery/docking/scorer.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scorer.py
@@ -25,7 +25,7 @@ from asapdiscovery.data.util.dask_utils import (
     dask_vmap,
 )
 from asapdiscovery.docking.docking import DockingResult
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 from asapdiscovery.ml.inference import InferenceBase, get_inference_cls_from_model_type
 from asapdiscovery.ml.models import MLModelSpecBase
 from asapdiscovery.spectrum.fitness import target_has_fitness_data

--- a/asapdiscovery-docking/asapdiscovery/docking/tests/test_docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/tests/test_docking.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 from asapdiscovery.docking.openeye import POSIT_METHOD, POSITDocker
 
 

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/cross_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/cross_docking.py
@@ -20,7 +20,7 @@ from asapdiscovery.docking.docking import (
     DockingInputMultiStructure,
     write_results_to_multi_sdf,
 )
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 from asapdiscovery.docking.openeye import POSIT_METHOD, POSIT_RELAX_MODE, POSITDocker
 from asapdiscovery.docking.scorer import ChemGauss4Scorer, MetaScorer
 from asapdiscovery.modeling.protein_prep import ProteinPrepper

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/large_scale_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/large_scale_docking.py
@@ -31,7 +31,7 @@ from asapdiscovery.data.util.logging import FileLogger
 from asapdiscovery.data.util.utils import check_empty_dataframe
 from asapdiscovery.dataviz.html_viz import ColorMethod, HTMLVisualizer
 from asapdiscovery.docking.docking import write_results_to_multi_sdf
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 from asapdiscovery.docking.openeye import POSITDocker
 from asapdiscovery.docking.scorer import (
     ChemGauss4Scorer,

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/ligand_transfer_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/ligand_transfer_docking.py
@@ -28,7 +28,7 @@ from asapdiscovery.data.util.utils import check_empty_dataframe
 from asapdiscovery.dataviz.gif_viz import GIFVisualizer
 from asapdiscovery.dataviz.html_viz import ColorMethod, HTMLVisualizer
 from asapdiscovery.docking.docking import write_results_to_multi_sdf
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 from asapdiscovery.docking.openeye import POSIT_METHOD, POSIT_RELAX_MODE, POSITDocker
 from asapdiscovery.docking.scorer import ChemGauss4Scorer, MetaScorer, MLModelScorer
 from asapdiscovery.ml.models import ASAPMLModelRegistry

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/small_scale_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/small_scale_docking.py
@@ -37,7 +37,7 @@ from asapdiscovery.data.util.utils import check_empty_dataframe
 from asapdiscovery.dataviz.gif_viz import GIFVisualizer
 from asapdiscovery.dataviz.html_viz import ColorMethod, HTMLVisualizer
 from asapdiscovery.docking.docking import write_results_to_multi_sdf
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 from asapdiscovery.docking.openeye import POSITDocker
 from asapdiscovery.docking.scorer import (
     ChemGauss4Scorer,

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/symexp_crystal_packing.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/symexp_crystal_packing.py
@@ -29,7 +29,7 @@ from asapdiscovery.data.util.dask_utils import BackendType, make_dask_client_met
 from asapdiscovery.data.util.logging import FileLogger
 from asapdiscovery.data.util.utils import check_empty_dataframe
 from asapdiscovery.docking.docking import write_results_to_multi_sdf
-from asapdiscovery.docking.docking_data_validation import DockingResultCols
+from asapdiscovery.data.schema.docking_data_validation import DockingResultCols
 from asapdiscovery.docking.openeye import POSITDocker
 from asapdiscovery.docking.scorer import ChemGauss4Scorer, SymClashScorer
 from asapdiscovery.modeling.protein_prep import ProteinPrepper


### PR DESCRIPTION
Closes #1292.

`DockingResultCols` was defined in `asapdiscovery.docking.docking_data_validation` but imported at runtime by `asapdiscovery.data.services.postera.manifold_artifacts`, creating a `data` → `docking` runtime dependency that undermines `data`'s role as the dependency-free foundation package.

It is just a `str` enum of column names with no docking logic, so it belongs in `data`.

## Changes
- Add `DockingResultCols` at `asapdiscovery.data.schema.docking_data_validation`.
- Replace the docking module with a **backwards-compatible re-export**, so existing `from asapdiscovery.docking.docking_data_validation import DockingResultCols` imports keep working (and `docking → data` is an allowed edge).
- Repoint all internal imports (data, dataviz, docking, workflows — 11 files) to the new location, breaking the `data → docking` edge.

## Verification
- `python -m py_compile` passes on every changed file.
- Loaded the new module directly: 22 columns, values unchanged (e.g. `LIGAND_ID = "ligand_id"`, `SYMEXP_CLASH_NUM = "symexp-clash-num"`).
- Confirmed no remaining imports of the old path outside the shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)