### PR TITLE
Drop multimethod dependency in favor of isinstance dispatch

### DIFF
--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
@@ -3,7 +3,6 @@ import shutil
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from multimethod import multimethod
 from pydantic import ConfigDict, Field, PositiveInt
 
 from asapdiscovery.data.metadata.resources import master_structures
@@ -94,9 +93,7 @@ class GIFVisualizer(VisualizerBase):
     interval: PositiveInt = Field(1, description="Interval between frames")
     debug: bool = Field(False, description="Whether to run in debug mode")
 
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True, ignored_types=(multimethod,)
-    )
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @dask_vmap(["inputs"], has_failure_mode=True)
     @backend_wrapper("inputs")
@@ -342,137 +339,142 @@ class GIFVisualizer(VisualizerBase):
 
         return path
 
-    @multimethod
     def _dispatch(
         self,
-        inputs: list[SimulationResult],
+        inputs,
         outpaths: Optional[list[Path]] = None,
         failure_mode: str = "skip",
         **kwargs,
     ):
-        data = []
+        """
+        Dispatch visualization based on the type of the input elements:
+        SimulationResults, or (trajectory_path, topology_path) tuples.
+        """
+        if not inputs:
+            return []
 
-        for i, res in enumerate(inputs):
-            try:
-                if not outpaths:
-                    if self.static_view_only:
-                        out = (
-                            self.output_dir
-                            / res.input_docking_result.unique_name
-                            / "view.pse"
-                        )
+        if isinstance(inputs[0], SimulationResult):
+            data = []
+
+            for i, res in enumerate(inputs):
+                try:
+                    if not outpaths:
+                        if self.static_view_only:
+                            out = (
+                                self.output_dir
+                                / res.input_docking_result.unique_name
+                                / "view.pse"
+                            )
+                        else:
+                            out = (
+                                self.output_dir
+                                / res.input_docking_result.unique_name
+                                / "trajectory.gif"
+                            )
                     else:
-                        out = (
-                            self.output_dir
-                            / res.input_docking_result.unique_name
-                            / "trajectory.gif"
+                        out = self.output_dir / outpaths[i]
+
+                    path = self.pymol_traj_viz(
+                        target=self.target,
+                        traj=res.traj_path,
+                        system=res.minimized_pdb_path,
+                        outpath=out,
+                        static_view_only=self.static_view_only,
+                        pse=self.pse,
+                        pse_share=self.pse_share,
+                        start=self.start,
+                        stop=self.stop,
+                        interval=self.interval,
+                        smooth=self.smooth,
+                        contacts=self.contacts,
+                        frames_per_ns=self.frames_per_ns,
+                        zoom_view=self.zoom_view,
+                        out_dir=self.output_dir,
+                    )
+                    row = {}
+                    row[DockingResultCols.LIGAND_ID.value] = (
+                        res.input_docking_result.posed_ligand.compound_name
+                    )
+                    row[DockingResultCols.TARGET_ID.value] = (
+                        res.input_docking_result.input_pair.complex.target.target_name
+                    )
+                    row[DockingResultCols.SMILES.value] = (
+                        res.input_docking_result.posed_ligand.smiles
+                    )
+                    row[DockingResultCols.GIF_PATH.value] = path
+                    data.append(row)
+                except Exception as e:
+                    if failure_mode == "skip":
+                        logger.error(
+                            f"Error processing {res.input_docking_result.unique_name}: {e}"
                         )
-                else:
-                    out = self.output_dir / outpaths[i]
-
-                path = self.pymol_traj_viz(
-                    target=self.target,
-                    traj=res.traj_path,
-                    system=res.minimized_pdb_path,
-                    outpath=out,
-                    static_view_only=self.static_view_only,
-                    pse=self.pse,
-                    pse_share=self.pse_share,
-                    start=self.start,
-                    stop=self.stop,
-                    interval=self.interval,
-                    smooth=self.smooth,
-                    contacts=self.contacts,
-                    frames_per_ns=self.frames_per_ns,
-                    zoom_view=self.zoom_view,
-                    out_dir=self.output_dir,
-                )
-                row = {}
-                row[DockingResultCols.LIGAND_ID.value] = (
-                    res.input_docking_result.posed_ligand.compound_name
-                )
-                row[DockingResultCols.TARGET_ID.value] = (
-                    res.input_docking_result.input_pair.complex.target.target_name
-                )
-                row[DockingResultCols.SMILES.value] = (
-                    res.input_docking_result.posed_ligand.smiles
-                )
-                row[DockingResultCols.GIF_PATH.value] = path
-                data.append(row)
-            except Exception as e:
-                if failure_mode == "skip":
-                    logger.error(
-                        f"Error processing {res.input_docking_result.unique_name}: {e}"
-                    )
-                elif failure_mode == "raise":
-                    raise e
-                else:
-                    raise ValueError(
-                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
-                    )
-        return data
-
-    @_dispatch.register
-    def _dispatch(
-        self,
-        inputs: list[tuple[Optional[Path], Path]],
-        outpaths: Optional[list[Path]] = None,
-        failure_mode: str = "skip",
-        **kwargs,
-    ):
-        data = []
-        for i, tup in enumerate(inputs):
-            try:
-                # unpack the tuple
-                traj, top = tup
-                # find with the unique identifier for the ligand would be
-                complex = Complex.from_pdb(
-                    top,
-                    target_kwargs={"target_name": f"{top.stem}_target"},
-                    ligand_kwargs={"compound_name": f"{top.stem}_ligand"},
-                )
-                csp = CompoundStructurePair(complex=complex, ligand=complex.ligand)
-                if not outpaths:
-                    if self.static_view_only:
-                        out = self.output_dir / csp.unique_name / "view.pse"
+                    elif failure_mode == "raise":
+                        raise e
                     else:
-                        out = self.output_dir / csp.unique_name / "trajectory.gif"
-                else:
-                    out = self.output_dir / outpaths[i]
+                        raise ValueError(
+                            f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+                        )
+            return data
 
-                path = self.pymol_traj_viz(
-                    target=self.target,
-                    traj=traj,
-                    system=top,
-                    outpath=out,
-                    static_view_only=self.static_view_only,
-                    pse=self.pse,
-                    pse_share=self.pse_share,
-                    start=self.start,
-                    stop=self.stop,
-                    interval=self.interval,
-                    smooth=self.smooth,
-                    contacts=self.contacts,
-                    frames_per_ns=self.frames_per_ns,
-                    zoom_view=self.zoom_view,
-                    out_dir=self.output_dir,
-                )
-                row = {}
-                row[DockingResultCols.LIGAND_ID.value] = complex.ligand.compound_name
-                row[DockingResultCols.TARGET_ID.value] = complex.target.target_name
-                row[DockingResultCols.SMILES.value] = complex.ligand.smiles
-                row[DockingResultCols.GIF_PATH.value] = path
-                data.append(row)
-            except Exception as e:
-                if failure_mode == "skip":
-                    logger.error(f"Error processing {csp.unique_name}: {e}")
-                elif failure_mode == "raise":
-                    raise e
-                else:
-                    raise ValueError(
-                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+        elif isinstance(inputs[0], tuple):
+            data = []
+            for i, tup in enumerate(inputs):
+                try:
+                    # unpack the tuple
+                    traj, top = tup
+                    # find with the unique identifier for the ligand would be
+                    complex = Complex.from_pdb(
+                        top,
+                        target_kwargs={"target_name": f"{top.stem}_target"},
+                        ligand_kwargs={"compound_name": f"{top.stem}_ligand"},
                     )
-        return data
+                    csp = CompoundStructurePair(complex=complex, ligand=complex.ligand)
+                    if not outpaths:
+                        if self.static_view_only:
+                            out = self.output_dir / csp.unique_name / "view.pse"
+                        else:
+                            out = self.output_dir / csp.unique_name / "trajectory.gif"
+                    else:
+                        out = self.output_dir / outpaths[i]
+
+                    path = self.pymol_traj_viz(
+                        target=self.target,
+                        traj=traj,
+                        system=top,
+                        outpath=out,
+                        static_view_only=self.static_view_only,
+                        pse=self.pse,
+                        pse_share=self.pse_share,
+                        start=self.start,
+                        stop=self.stop,
+                        interval=self.interval,
+                        smooth=self.smooth,
+                        contacts=self.contacts,
+                        frames_per_ns=self.frames_per_ns,
+                        zoom_view=self.zoom_view,
+                        out_dir=self.output_dir,
+                    )
+                    row = {}
+                    row[DockingResultCols.LIGAND_ID.value] = complex.ligand.compound_name
+                    row[DockingResultCols.TARGET_ID.value] = complex.target.target_name
+                    row[DockingResultCols.SMILES.value] = complex.ligand.smiles
+                    row[DockingResultCols.GIF_PATH.value] = path
+                    data.append(row)
+                except Exception as e:
+                    if failure_mode == "skip":
+                        logger.error(f"Error processing {csp.unique_name}: {e}")
+                    elif failure_mode == "raise":
+                        raise e
+                    else:
+                        raise ValueError(
+                            f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+                        )
+            return data
+
+        else:
+            raise NotImplementedError(
+                f"Cannot dispatch visualization on inputs of type {type(inputs[0])}"
+            )
 
 
 def add_gif_progress_bar(

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
@@ -11,8 +11,7 @@ import logomaker
 import matplotlib.pyplot as plt
 import pandas as pd
 from airium import Airium
-from multimethod import multimethod
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 
 from asapdiscovery.data.backend.openeye import (
     combine_protein_ligand,
@@ -24,7 +23,6 @@ from asapdiscovery.data.backend.openeye import (
 )
 from asapdiscovery.data.metadata.resources import active_site_chains, master_structures
 from asapdiscovery.data.schema.complex import Complex
-from asapdiscovery.data.schema.ligand import Ligand
 from asapdiscovery.data.services.postera.manifold_data_validation import (
     TargetTags,
     TargetVirusMap,
@@ -107,8 +105,6 @@ class HTMLVisualizer(VisualizerBase):
     fitness_data_logoplots: Optional[Any] = None
     reference_protein: Optional[Any] = None
 
-    model_config = ConfigDict(ignored_types=(multimethod,))
-
     @model_validator(mode="before")
     @classmethod
     def check_and_set_chains(cls, values):
@@ -183,255 +179,195 @@ class HTMLVisualizer(VisualizerBase):
     def provenance(self):
         return {}
 
-    @multimethod
     def _dispatch(
         self,
-        inputs: list[DockingResult],
+        inputs,
         outpaths: Optional[list[Path]] = None,
         failure_mode: str = "skip",
         **kwargs,
     ) -> Union[list[dict[str, str]], list[str]]:
         """
-        Implementation for a list of DockingResult objects.
-
-        Parameters
-        ----------
-        inputs : list[DockingResult]
-            List of DockingResult objects
-        outpaths : Optional[list[Path]], optional
-            List of output paths, by default None
-
-        Returns
-        -------
-        Union[list[dict[str, str]], list[str]]
-            List of metadata dictionaries or list of HTML strings if write_to_disk is False
+        Dispatch visualization based on the type of the input elements:
+        DockingResults, Complexes, Paths to PDB files, or
+        (Complex, list[Ligand]) tuples.
         """
-        data = []
-        viz_data = []
+        if not inputs:
+            return []
 
-        for i, result in enumerate(inputs):
-            try:
-                output_pref = result.unique_name
-                if self.write_to_disk:
-                    if not outpaths:
-                        outpath = self.output_dir / output_pref / "pose.html"
+        if isinstance(inputs[0], DockingResult):
+            data = []
+            viz_data = []
+
+            for i, result in enumerate(inputs):
+                try:
+                    output_pref = result.unique_name
+                    if self.write_to_disk:
+                        if not outpaths:
+                            outpath = self.output_dir / output_pref / "pose.html"
+                        else:
+                            outpath = self.output_dir / Path(outpaths[i])
+                        outpath.parent.mkdir(parents=True, exist_ok=True)
                     else:
-                        outpath = self.output_dir / Path(outpaths[i])
-                    outpath.parent.mkdir(parents=True, exist_ok=True)
-                else:
-                    outpath = None  # we don't need to write to disk
+                        outpath = None  # we don't need to write to disk
 
-                viz = self.html_pose_viz(
-                    poses=[result.posed_ligand.to_oemol()], protein=result.to_protein()
-                )
-                viz_data.append(viz)
-                # write to disk
-                if self.write_to_disk:
-                    self.write_html(viz, outpath)
-
-                # make dataframe with ligand name, target name, and path to HTML
-                row = {}
-                row[DockingResultCols.LIGAND_ID.value] = (
-                    result.input_pair.ligand.compound_name
-                )
-                row[DockingResultCols.TARGET_ID.value] = (
-                    result.input_pair.complex.target.target_name
-                )
-                row[DockingResultCols.SMILES.value] = result.posed_ligand.smiles
-                row[self.get_tag_for_color_method()] = outpath
-                data.append(row)
-            except Exception as e:
-                if failure_mode == "skip":
-                    logger.error(f"Error processing {result.unique_name}: {e}")
-                elif failure_mode == "raise":
-                    raise e
-                else:
-                    raise ValueError(
-                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+                    viz = self.html_pose_viz(
+                        poses=[result.posed_ligand.to_oemol()],
+                        protein=result.to_protein(),
                     )
+                    viz_data.append(viz)
+                    # write to disk
+                    if self.write_to_disk:
+                        self.write_html(viz, outpath)
 
-        if self.write_to_disk:
-            return data
-        else:
-            return viz_data
+                    # make dataframe with ligand name, target name, and path to HTML
+                    row = {}
+                    row[DockingResultCols.LIGAND_ID.value] = (
+                        result.input_pair.ligand.compound_name
+                    )
+                    row[DockingResultCols.TARGET_ID.value] = (
+                        result.input_pair.complex.target.target_name
+                    )
+                    row[DockingResultCols.SMILES.value] = result.posed_ligand.smiles
+                    row[self.get_tag_for_color_method()] = outpath
+                    data.append(row)
+                except Exception as e:
+                    if failure_mode == "skip":
+                        logger.error(f"Error processing {result.unique_name}: {e}")
+                    elif failure_mode == "raise":
+                        raise e
+                    else:
+                        raise ValueError(
+                            f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+                        )
 
-    @_dispatch.register
-    def _dispatch(
-        self, inputs: list[Path], outpaths: Optional[list[Path]] = None, **kwargs
-    ) -> Union[list[dict[str, str]], list[str]]:
-        """
-        Implementation for a list of Path objects. Assumes that the Path objects are PDB files.
-        in turn calls the Complex version of the dispatch.
+            if self.write_to_disk:
+                return data
+            else:
+                return viz_data
 
-        Parameters
-        ----------
-        inputs : list[Path]
-            List of Path objects
-        outpaths : Optional[list[Path]], optional
-            List of output paths, by default None
+        elif isinstance(inputs[0], Complex):
+            data = []
+            viz_data = []
+            for i, cmplx in enumerate(inputs):
+                try:
+                    if self.write_to_disk:
+                        if not outpaths:
+                            output_pref = cmplx.unique_name
+                            outpath = self.output_dir / output_pref / "pose.html"
+                        else:
+                            outpath = self.output_dir / Path(outpaths[i])
 
-        Returns
-        -------
-        Union[list[dict[str, str]], list[str]]
-            List of metadata dictionaries or list of HTML strings if write_to_disk is False
-        """
-        complexes = [
-            Complex.from_pdb(
-                p,
-                target_kwargs={"target_name": f"{p.stem}_target"},
-                ligand_kwargs={"compound_name": f"{p.stem}_ligand"},
+                        outpath.parent.mkdir(parents=True, exist_ok=True)
+                    else:
+                        outpath = None
+
+                    # make html string
+                    viz = self.html_pose_viz(
+                        poses=[cmplx.ligand.to_oemol()], protein=cmplx.target.to_oemol()
+                    )
+                    viz_data.append(viz)
+                    # write to disk
+                    if self.write_to_disk:
+                        self.write_html(viz, outpath)
+
+                    # make dataframe with ligand name, target name, and path to HTML
+                    row = {}
+                    row[DockingResultCols.LIGAND_ID.value] = cmplx.ligand.compound_name
+                    row[DockingResultCols.TARGET_ID.value] = cmplx.target.target_name
+                    row[DockingResultCols.SMILES.value] = cmplx.ligand.smiles
+                    row[self.get_tag_for_color_method()] = outpath
+                    data.append(row)
+                except Exception as e:
+                    if failure_mode == "skip":
+                        logger.error(f"Error processing {cmplx.unique_name}: {e}")
+                    elif failure_mode == "raise":
+                        raise e
+                    else:
+                        raise ValueError(
+                            f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+                        )
+
+            if self.write_to_disk:
+                # if we are writing to disk, return the metadata
+                return data
+            else:
+                # if we are not writing to disk, return the HTML strings
+                return viz_data
+
+        elif isinstance(inputs[0], Path):
+            # assuming reading PDB files from disk; dispatch to the Complex branch
+            complexes = [
+                Complex.from_pdb(
+                    p,
+                    target_kwargs={"target_name": f"{p.stem}_target"},
+                    ligand_kwargs={"compound_name": f"{p.stem}_ligand"},
+                )
+                for i, p in enumerate(inputs)
+            ]
+            return self._dispatch(
+                complexes, outpaths=outpaths, failure_mode=failure_mode, **kwargs
             )
-            for i, p in enumerate(inputs)
-        ]
-        # dispatch to complex version
-        return self._dispatch(complexes, outpaths=outpaths, **kwargs)
 
-    @_dispatch.register
-    def _dispatch(
-        self,
-        inputs: list[Complex],
-        outpaths: Optional[list[Path]] = None,
-        failure_mode: str = "skip",
-        **kwargs,
-    ) -> Union[list[dict[str, str]], list[str]]:
-        """
-        Implementation for a list of Complex objects.
-
-        Parameters
-        ----------
-        inputs : list[Complex]
-            List of Complex objects
-        outpaths : Optional[list[Path]], optional
-            List of output paths, by default None
-
-        Returns
-        -------
-        Union[list[dict[str, str]], list[str]]
-            List of metadata dictionaries or list of HTML strings if write_to_disk is False
-        """
-        data = []
-        viz_data = []
-        for i, cmplx in enumerate(inputs):
-            try:
-                if self.write_to_disk:
-                    if not outpaths:
-                        output_pref = cmplx.unique_name
-                        outpath = self.output_dir / output_pref / "pose.html"
+        elif isinstance(inputs[0], tuple):
+            # each input is a (Complex, list[Ligand]) tuple; every ligand in the
+            # list is visualized, useful for multiple poses of a single ligand,
+            # or multiple ligands in a single complex.
+            data = []
+            viz_data = []
+            for i, inp in enumerate(inputs):
+                try:
+                    cmplx, liglist = inp
+                    if self.write_to_disk:
+                        if not outpaths:
+                            output_pref = cmplx.unique_name
+                            outpath = self.output_dir / output_pref / "pose.html"
+                        else:
+                            outpath = self.output_dir / Path(outpaths[i])
+                        outpath.parent.mkdir(parents=True, exist_ok=True)
                     else:
-                        outpath = self.output_dir / Path(outpaths[i])
+                        outpath = None
 
-                    outpath.parent.mkdir(parents=True, exist_ok=True)
-                else:
-                    outpath = None
-
-                # make html string
-                viz = self.html_pose_viz(
-                    poses=[cmplx.ligand.to_oemol()], protein=cmplx.target.to_oemol()
-                )
-                viz_data.append(viz)
-                # write to disk
-                if self.write_to_disk:
-                    self.write_html(viz, outpath)
-
-                # make dataframe with ligand name, target name, and path to HTML
-                row = {}
-                row[DockingResultCols.LIGAND_ID.value] = cmplx.ligand.compound_name
-                row[DockingResultCols.TARGET_ID.value] = cmplx.target.target_name
-                row[DockingResultCols.SMILES.value] = cmplx.ligand.smiles
-                row[self.get_tag_for_color_method()] = outpath
-                data.append(row)
-            except Exception as e:
-                if failure_mode == "skip":
-                    logger.error(f"Error processing {cmplx.unique_name}: {e}")
-                elif failure_mode == "raise":
-                    raise e
-                else:
-                    raise ValueError(
-                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+                    # make html string
+                    viz = self.html_pose_viz(
+                        poses=[lig.to_oemol() for lig in liglist],
+                        protein=cmplx.target.to_oemol(),
                     )
+                    viz_data.append(viz)
+                    # write to disk
+                    if self.write_to_disk:
+                        self.write_html(viz, outpath)
 
-        if self.write_to_disk:
-            # if we are writing to disk, return the metadata
-            return data
-        else:
-            # if we are not writing to disk, return the HTML strings
-            return viz_data
-
-    @_dispatch.register
-    def _dispatch(
-        self,
-        inputs: list[tuple[Complex, list[Ligand]]],
-        outpaths: Optional[list[Path]] = None,
-        failure_mode: str = "skip",
-        **kwargs,
-    ) -> Union[list[dict[str, str]], list[str]]:
-        """
-        Implementation for a list of tuples of Complex and list of Ligand objects. Each ligand in the list is visualized, making this perfect for
-        visualizing multiple poses of a single ligand, or multiple ligands in a single complex.
-
-        Parameters
-        ----------
-        inputs : list[tuple[Complex, list[Ligand]]]
-            List of tuples of Complex and list of Ligand objects
-        outpaths : Optional[list[Path]], optional
-            List of output paths, by default None
-
-        Returns
-        -------
-        Union[list[dict[str, str]], list[str]]
-            List of metadata dictionaries or list of HTML strings if write_to_disk is False
-        """
-        data = []
-        viz_data = []
-        for i, inp in enumerate(inputs):
-            try:
-                cmplx, liglist = inp
-                if self.write_to_disk:
-                    if not outpaths:
-                        output_pref = cmplx.unique_name
-                        outpath = self.output_dir / output_pref / "pose.html"
+                    # make dataframe with ligand name, target name, and path to HTML
+                    row = {}
+                    row[DockingResultCols.LIGAND_ID.value] = cmplx.ligand.compound_name
+                    row[DockingResultCols.TARGET_ID.value] = cmplx.target.target_name
+                    if len(liglist) > 1:
+                        row[DockingResultCols.SMILES.value] = "MANY"
                     else:
-                        outpath = self.output_dir / Path(outpaths[i])
-                    outpath.parent.mkdir(parents=True, exist_ok=True)
-                else:
-                    outpath = None
+                        row[DockingResultCols.SMILES.value] = liglist[0].smiles
+                    row[self.get_tag_for_color_method()] = outpath
+                    data.append(row)
+                except Exception as e:
+                    if failure_mode == "skip":
+                        logger.error(f"Error processing {cmplx.unique_name}: {e}")
+                    elif failure_mode == "raise":
+                        raise e
+                    else:
+                        raise ValueError(
+                            f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+                        )
 
-                # make html string
-                viz = self.html_pose_viz(
-                    poses=[lig.to_oemol() for lig in liglist],
-                    protein=cmplx.target.to_oemol(),
-                )
-                viz_data.append(viz)
-                # write to disk
-                if self.write_to_disk:
-                    self.write_html(viz, outpath)
+            if self.write_to_disk:
+                # if we are writing to disk, return the metadata
+                return data
+            else:
+                # if we are not writing to disk, return the HTML strings
+                return viz_data
 
-                # make dataframe with ligand name, target name, and path to HTML
-                row = {}
-                row[DockingResultCols.LIGAND_ID.value] = cmplx.ligand.compound_name
-                row[DockingResultCols.TARGET_ID.value] = cmplx.target.target_name
-                if len(liglist) > 1:
-                    row[DockingResultCols.SMILES.value] = "MANY"
-                else:
-                    row[DockingResultCols.SMILES.value] = liglist[0].smiles
-                row[self.get_tag_for_color_method()] = outpath
-                data.append(row)
-            except Exception as e:
-                if failure_mode == "skip":
-                    logger.error(f"Error processing {cmplx.unique_name}: {e}")
-                elif failure_mode == "raise":
-                    raise e
-                else:
-                    raise ValueError(
-                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
-                    )
-
-        if self.write_to_disk:
-            # if we are writing to disk, return the metadata
-            return data
         else:
-            # if we are not writing to disk, return the HTML strings
-            return viz_data
+            raise NotImplementedError(
+                f"Cannot dispatch visualization on inputs of type {type(inputs[0])}"
+            )
 
     def html_pose_viz(
         self, poses: list[oechem.OEMolBase], protein: oechem.OEMolBase, **kwargs

--- a/asapdiscovery-docking/asapdiscovery/docking/scorer.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scorer.py
@@ -10,8 +10,7 @@ import MDAnalysis as mda
 import numpy as np
 import pandas as pd
 from mtenn.config import ModelType
-from multimethod import multimethod
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from asapdiscovery.data.backend.openeye import oedocking, oemol_to_pdb_string
 from asapdiscovery.data.schema.complex import Complex
@@ -118,8 +117,6 @@ class Score(BaseModel):
     Result of scoring, we don't embed the input result because it can be large,
     instead we just store the input result ids.
     """
-
-    model_config = ConfigDict(ignored_types=(multimethod,))
 
     score_type: ScoreType
     score: float
@@ -260,8 +257,6 @@ class ScorerBase(BaseModel):
     Base class for scoring functions.
     """
 
-    model_config = ConfigDict(ignored_types=(multimethod,))
-
     score_type: ScoreType = Field(ScoreType.INVALID, description="Type of score")
     score_units: ClassVar[ScoreUnits.INVALID] = ScoreUnits.INVALID
 
@@ -392,69 +387,70 @@ class ChemGauss4Scorer(ScorerBase):
             inputs, return_for_disk_backend=return_for_disk_backend, **kwargs
         )
 
-    @multimethod
     def _dispatch(
         self,
-        inputs: list[DockingResult],
+        inputs,
         return_for_disk_backend: bool = False,
         **kwargs,
     ) -> list[Score]:
         """
-        Dispatch for DockingResults
+        Dispatch scoring based on the type of the input elements
+        (DockingResults, Complexes, or Paths to PDB files).
         """
-        results = []
-        for inp in inputs:
-            posed_mol = inp.posed_ligand.to_oemol()
-            pose_scorer = oedocking.OEScore(oedocking.OEScoreType_Chemgauss4)
-            du = inp.input_pair.complex.target.to_oedu()
-            pose_scorer.Initialize(du)
-            chemgauss_score = pose_scorer.ScoreLigand(posed_mol)
+        if not inputs:
+            return []
 
-            sc = Score.from_score_and_docking_result(
-                chemgauss_score, self.score_type, self.units, inp
-            )
+        if isinstance(inputs[0], DockingResult):
+            results = []
+            for inp in inputs:
+                posed_mol = inp.posed_ligand.to_oemol()
+                pose_scorer = oedocking.OEScore(oedocking.OEScoreType_Chemgauss4)
+                du = inp.input_pair.complex.target.to_oedu()
+                pose_scorer.Initialize(du)
+                chemgauss_score = pose_scorer.ScoreLigand(posed_mol)
 
-            # overwrite the input with the path to the file
-            if return_for_disk_backend:
-                sc.input = _get_disk_path_from_docking_result(inp)
-
-            results.append(sc)
-        return results
-
-    @_dispatch.register
-    def _dispatch(self, inputs: list[Complex], **kwargs) -> list[Score]:
-        """
-        Dispatch for Complexes
-        """
-        results = []
-        for inp in inputs:
-            posed_mol = inp.ligand.to_oemol()
-            pose_scorer = oedocking.OEScore(oedocking.OEScoreType_Chemgauss4)
-            receptor = inp.target.to_oemol()
-            pose_scorer.Initialize(receptor)
-            chemgauss_score = pose_scorer.ScoreLigand(posed_mol)
-            results.append(
-                Score.from_score_and_complex(
+                sc = Score.from_score_and_docking_result(
                     chemgauss_score, self.score_type, self.units, inp
                 )
-            )
-        return results
 
-    @_dispatch.register
-    def _dispatch(self, inputs: list[Path], **kwargs) -> list[Score]:
-        """
-        Dispatch for PDB files from disk
-        """
-        # assuming reading PDB files from disk
-        complexes = [
-            Complex.from_pdb(
-                p,
-                ligand_kwargs={"compound_name": f"{p.stem}_ligand"},
-                target_kwargs={"target_name": f"{p.stem}_target"},
+                # overwrite the input with the path to the file
+                if return_for_disk_backend:
+                    sc.input = _get_disk_path_from_docking_result(inp)
+
+                results.append(sc)
+            return results
+
+        elif isinstance(inputs[0], Complex):
+            results = []
+            for inp in inputs:
+                posed_mol = inp.ligand.to_oemol()
+                pose_scorer = oedocking.OEScore(oedocking.OEScoreType_Chemgauss4)
+                receptor = inp.target.to_oemol()
+                pose_scorer.Initialize(receptor)
+                chemgauss_score = pose_scorer.ScoreLigand(posed_mol)
+                results.append(
+                    Score.from_score_and_complex(
+                        chemgauss_score, self.score_type, self.units, inp
+                    )
+                )
+            return results
+
+        elif isinstance(inputs[0], Path):
+            # assuming reading PDB files from disk
+            complexes = [
+                Complex.from_pdb(
+                    p,
+                    ligand_kwargs={"compound_name": f"{p.stem}_ligand"},
+                    target_kwargs={"target_name": f"{p.stem}_target"},
+                )
+                for p in inputs
+            ]
+            return self._dispatch(complexes)
+
+        else:
+            raise NotImplementedError(
+                f"Cannot dispatch scoring on inputs of type {type(inputs[0])}"
             )
-            for p in inputs
-        ]
-        return self._dispatch(complexes)
 
 
 class FINTScorer(ScorerBase):
@@ -492,66 +488,67 @@ class FINTScorer(ScorerBase):
             inputs, return_for_disk_backend=return_for_disk_backend, **kwargs
         )
 
-    @multimethod
     def _dispatch(
         self,
-        inputs: list[DockingResult],
+        inputs,
         return_for_disk_backend: bool = False,
         **kwargs,
     ) -> list[Score]:
         """
-        Dispatch for DockingResults
+        Dispatch scoring based on the type of the input elements
+        (DockingResults, Complexes, or Paths to PDB files).
         """
-        results = []
-        for inp in inputs:
-            _, fint_score = compute_fint_score(
-                inp.to_protein(), inp.posed_ligand.to_oemol(), self.target
-            )
+        if not inputs:
+            return []
 
-            sc = Score.from_score_and_docking_result(
-                fint_score, self.score_type, self.units, inp
-            )
-            # overwrite the input with the path to the file
-            if return_for_disk_backend:
-                sc.input = _get_disk_path_from_docking_result(inp)
+        if isinstance(inputs[0], DockingResult):
+            results = []
+            for inp in inputs:
+                _, fint_score = compute_fint_score(
+                    inp.to_protein(), inp.posed_ligand.to_oemol(), self.target
+                )
 
-            results.append(sc)
-
-        return results
-
-    @_dispatch.register
-    def _dispatch(self, inputs: list[Complex], **kwargs):
-        """
-        Dispatch for Complexes
-        """
-        results = []
-        for inp in inputs:
-            _, fint_score = compute_fint_score(
-                inp.target.to_oemol(), inp.ligand.to_oemol(), self.target
-            )
-            results.append(
-                Score.from_score_and_complex(
+                sc = Score.from_score_and_docking_result(
                     fint_score, self.score_type, self.units, inp
                 )
-            )
-        return results
+                # overwrite the input with the path to the file
+                if return_for_disk_backend:
+                    sc.input = _get_disk_path_from_docking_result(inp)
 
-    @_dispatch.register
-    def _dispatch(self, inputs: list[Path], **kwargs):
-        """
-        Dispatch for PDB files from disk
-        """
-        # assuming reading PDB files from disk
-        complexes = [
-            Complex.from_pdb(
-                p,
-                ligand_kwargs={"compound_name": f"{p.stem}_ligand"},
-                target_kwargs={"target_name": f"{p.stem}_target"},
-            )
-            for p in inputs
-        ]
+                results.append(sc)
 
-        return self._dispatch(complexes, **kwargs)
+            return results
+
+        elif isinstance(inputs[0], Complex):
+            results = []
+            for inp in inputs:
+                _, fint_score = compute_fint_score(
+                    inp.target.to_oemol(), inp.ligand.to_oemol(), self.target
+                )
+                results.append(
+                    Score.from_score_and_complex(
+                        fint_score, self.score_type, self.units, inp
+                    )
+                )
+            return results
+
+        elif isinstance(inputs[0], Path):
+            # assuming reading PDB files from disk
+            complexes = [
+                Complex.from_pdb(
+                    p,
+                    ligand_kwargs={"compound_name": f"{p.stem}_ligand"},
+                    target_kwargs={"target_name": f"{p.stem}_target"},
+                )
+                for p in inputs
+            ]
+
+            return self._dispatch(complexes, **kwargs)
+
+        else:
+            raise NotImplementedError(
+                f"Cannot dispatch scoring on inputs of type {type(inputs[0])}"
+            )
 
 
 # keep track of all the ml scorers
@@ -697,73 +694,76 @@ class GATScorer(MLModelScorer):
             inputs, return_for_disk_backend=return_for_disk_backend, **kwargs
         )
 
-    @multimethod
     def _dispatch(
         self,
-        inputs: list[DockingResult],
+        inputs,
         return_for_disk_backend: bool = False,
         **kwargs,
     ) -> list[Score]:
         """
-        Dispatch for DockingResults
+        Dispatch scoring based on the type of the input elements
+        (DockingResults, SMILES strings, or Ligands).
         """
-        results = []
-        for inp in inputs:
-            gat_score = self.inference_cls.predict_from_smiles(inp.posed_ligand.smiles)
-            sc = Score.from_score_and_docking_result(
-                gat_score,
-                self.score_type,
-                self.units,
-                inp,
-            )
-            # overwrite the input with the path to the file
-            if return_for_disk_backend:
-                sc.input = _get_disk_path_from_docking_result(inp)
-            results.append(sc)
-        return results
+        if not inputs:
+            return []
 
-    @_dispatch.register
-    def _dispatch(self, inputs: list[str], **kwargs) -> list[Score]:
-        """
-        Dispatch for SMILES strings
-        """
-        results = []
-        for inp in inputs:
-            gat_score = self.inference_cls.predict_from_smiles(inp)
-            results.append(
-                Score.from_score_and_smiles(
+        if isinstance(inputs[0], DockingResult):
+            results = []
+            for inp in inputs:
+                gat_score = self.inference_cls.predict_from_smiles(
+                    inp.posed_ligand.smiles
+                )
+                sc = Score.from_score_and_docking_result(
                     gat_score,
-                    inp,
                     self.score_type,
                     self.units,
-                )
-            )
-        return results
-
-    @_dispatch.register
-    def _dispatch(self, inputs: list[Ligand], **kwargs) -> list[Score]:
-        """
-        Dispatch for Ligands
-        """
-        results = []
-        for inp in inputs:
-            gat_score = self.inference_cls.predict_from_smiles(inp.smiles)
-            results.append(
-                Score.from_score_and_ligand(
-                    gat_score,
                     inp,
-                    self.score_type,
-                    self.units,
                 )
+                # overwrite the input with the path to the file
+                if return_for_disk_backend:
+                    sc.input = _get_disk_path_from_docking_result(inp)
+                results.append(sc)
+            return results
+
+        elif isinstance(inputs[0], Ligand):
+            results = []
+            for inp in inputs:
+                gat_score = self.inference_cls.predict_from_smiles(inp.smiles)
+                results.append(
+                    Score.from_score_and_ligand(
+                        gat_score,
+                        inp,
+                        self.score_type,
+                        self.units,
+                    )
+                )
+            return results
+
+        elif isinstance(inputs[0], str):
+            results = []
+            for inp in inputs:
+                gat_score = self.inference_cls.predict_from_smiles(inp)
+                results.append(
+                    Score.from_score_and_smiles(
+                        gat_score,
+                        inp,
+                        self.score_type,
+                        self.units,
+                    )
+                )
+            return results
+
+        else:
+            raise NotImplementedError(
+                f"Cannot dispatch scoring on inputs of type {type(inputs[0])}"
             )
-        return results
 
 
 class E3MLModelScorer(MLModelScorer):
     """
     Scoring using ML Models that operate over 3D structures
-    These all share an interface so we can use multimethods to dispatch
-    for the different input types for all subclasses.
+    These all share an interface so we can dispatch on the input type
+    for all subclasses.
     """
 
     model_type: ClassVar[ModelType.INVALID] = ModelType.INVALID
@@ -781,49 +781,61 @@ class E3MLModelScorer(MLModelScorer):
             inputs, return_for_disk_backend=return_for_disk_backend, **kwargs
         )
 
-    @multimethod
     def _dispatch(
         self,
-        inputs: list[DockingResult],
+        inputs,
         return_for_disk_backend: bool = False,
         **kwargs,
     ) -> list[Score]:
-        results = []
-        for inp in inputs:
-            score = self.inference_cls.predict_from_oemol(inp.to_posed_oemol())
+        """
+        Dispatch scoring based on the type of the input elements
+        (DockingResults, Complexes, or Paths to PDB files).
+        """
+        if not inputs:
+            return []
 
-            sc = Score.from_score_and_docking_result(
-                score, self.score_type, self.units, inp
+        if isinstance(inputs[0], DockingResult):
+            results = []
+            for inp in inputs:
+                score = self.inference_cls.predict_from_oemol(inp.to_posed_oemol())
+
+                sc = Score.from_score_and_docking_result(
+                    score, self.score_type, self.units, inp
+                )
+                # overwrite the input with the path to the file
+                if return_for_disk_backend:
+                    sc.input = _get_disk_path_from_docking_result(inp)
+                results.append(sc)
+
+            return results
+
+        elif isinstance(inputs[0], Complex):
+            results = []
+            for inp in inputs:
+                score = self.inference_cls.predict_from_oemol(inp.to_combined_oemol())
+                results.append(
+                    Score.from_score_and_complex(
+                        score, self.score_type, self.units, inp
+                    )
+                )
+            return results
+
+        elif isinstance(inputs[0], Path):
+            # assuming reading PDB files from disk
+            complexes = [
+                Complex.from_pdb(
+                    p,
+                    ligand_kwargs={"compound_name": f"{p.stem}_ligand"},
+                    target_kwargs={"target_name": f"{p.stem}_target"},
+                )
+                for i, p in enumerate(inputs)
+            ]
+            return self._dispatch(complexes, **kwargs)
+
+        else:
+            raise NotImplementedError(
+                f"Cannot dispatch scoring on inputs of type {type(inputs[0])}"
             )
-            # overwrite the input with the path to the file
-            if return_for_disk_backend:
-                sc.input = _get_disk_path_from_docking_result(inp)
-            results.append(sc)
-
-        return results
-
-    @_dispatch.register
-    def _dispatch(self, inputs: list[Complex], **kwargs) -> list[Score]:
-        results = []
-        for inp in inputs:
-            score = self.inference_cls.predict_from_oemol(inp.to_combined_oemol())
-            results.append(
-                Score.from_score_and_complex(score, self.score_type, self.units, inp)
-            )
-        return results
-
-    @_dispatch.register
-    def _dispatch(self, inputs: list[Path], **kwargs) -> list[Score]:
-        # assuming reading PDB files from disk
-        complexes = [
-            Complex.from_pdb(
-                p,
-                ligand_kwargs={"compound_name": f"{p.stem}_ligand"},
-                target_kwargs={"target_name": f"{p.stem}_target"},
-            )
-            for i, p in enumerate(inputs)
-        ]
-        return self._dispatch(complexes, **kwargs)
 
 
 @register_ml_scorer
@@ -860,8 +872,6 @@ class MetaScorer(BaseModel):
     """
     Score from a combination of other scorers, the scorers must share an input type,
     """
-
-    model_config = ConfigDict(ignored_types=(multimethod,))
 
     scorers: list[ScorerBase] = Field(..., description="Scorers to score with")
 
@@ -927,11 +937,18 @@ class SymClashScorer(ScorerBase):
         """
         return self._dispatch(inputs, **kwargs)
 
-    @multimethod
-    def _dispatch(self, inputs: list[Complex], **kwargs) -> list[Score]:
+    def _dispatch(self, inputs, **kwargs) -> list[Score]:
         """
-        Dispatch for Complex
+        Dispatch scoring for Complexes.
         """
+        if not inputs:
+            return []
+
+        if not isinstance(inputs[0], Complex):
+            raise NotImplementedError(
+                f"Cannot dispatch scoring on inputs of type {type(inputs[0])}"
+            )
+
         results = []
         warnings.warn(
             "SymClashScorer relies on expanded protein units having chain X as constructed by SymmetryExpander"

--- a/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
@@ -10,7 +10,6 @@ import openmm
 import pandas as pd
 from mdtraj.core.residue_names import _SOLVENT_TYPES
 from mdtraj.reporters import XTCReporter
-from multimethod import multimethod
 from openff.toolkit.topology import Molecule
 from openmm import LangevinMiddleIntegrator, MonteCarloBarostat, Platform, app, unit
 from openmm.app import Modeller, PDBFile, Simulation, StateDataReporter
@@ -206,7 +205,6 @@ class VanillaMDSimulator(SimulatorBase):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         extra="allow",
-        ignored_types=(multimethod,),
     )
 
     @model_validator(mode="after")
@@ -296,69 +294,79 @@ class VanillaMDSimulator(SimulatorBase):
 
         return self._dispatch(inputs, outpaths=outpaths, **kwargs)
 
-    @multimethod
-    def _dispatch(
-        self, inputs: list[DockingResult], failure_mode: str = "skip", **kwargs
-    ):
-        # outpaths is unused in this overload
-        results = []
-        for inp in inputs:
-            try:
-                output_pref = inp.unique_name
-                outpath = self.output_dir / output_pref
-                if not outpath.exists():
-                    outpath.mkdir(parents=True)
-                posed_sdf_path = outpath / "posed_ligand.sdf"
-                inp.posed_ligand.to_sdf(posed_sdf_path)
-                # write pdb to pre file
-                pre_pdb_path = outpath / "pre.pdb"
-                save_openeye_pdb(inp.to_protein(), pre_pdb_path)
-                res = self._simulate_loop(
-                    pre_pdb_path, posed_sdf_path, outpath, input_docking_result=inp
-                )
-                results.append(res)
-            except Exception as e:
-                if failure_mode == "skip":
-                    logger.error(f"Error processing {inp.unique_name}: {e}")
-                elif failure_mode == "raise":
-                    raise e
-                else:
-                    raise ValueError(
-                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
-                    )
-        return results
-
-    @_dispatch.register
     def _dispatch(
         self,
-        inputs: list[tuple[Path, Path]],
+        inputs,
         outpaths: Optional[list[Path]] = None,
         failure_mode: str = "skip",
+        **kwargs,
     ):
-        results = []
-        if not outpaths:
-            outpaths = [None] * len(inputs)
-        for (protein, ligand), outpath in zip(inputs, outpaths):
-            try:
-                tag = protein.stem + "_" + ligand.stem
-                if outpath:
-                    outpath = Path(outpath) / tag
-                else:
-                    outpath = self.output_dir / tag
-                if not outpath.exists():
-                    outpath.mkdir(parents=True)
-                res = self._simulate_loop(protein, ligand, outpath)
-                results.append(res)
-            except Exception as e:
-                if failure_mode == "skip":
-                    logger.error(f"Error processing {tag}: {e}")
-                elif failure_mode == "raise":
-                    raise e
-                else:
-                    raise ValueError(
-                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+        """
+        Dispatch simulation based on the type of the input elements:
+        DockingResults, or (protein_path, ligand_path) tuples.
+        """
+        if not inputs:
+            return []
+
+        if isinstance(inputs[0], DockingResult):
+            # outpaths is unused for DockingResult inputs
+            results = []
+            for inp in inputs:
+                try:
+                    output_pref = inp.unique_name
+                    outpath = self.output_dir / output_pref
+                    if not outpath.exists():
+                        outpath.mkdir(parents=True)
+                    posed_sdf_path = outpath / "posed_ligand.sdf"
+                    inp.posed_ligand.to_sdf(posed_sdf_path)
+                    # write pdb to pre file
+                    pre_pdb_path = outpath / "pre.pdb"
+                    save_openeye_pdb(inp.to_protein(), pre_pdb_path)
+                    res = self._simulate_loop(
+                        pre_pdb_path, posed_sdf_path, outpath, input_docking_result=inp
                     )
-        return results
+                    results.append(res)
+                except Exception as e:
+                    if failure_mode == "skip":
+                        logger.error(f"Error processing {inp.unique_name}: {e}")
+                    elif failure_mode == "raise":
+                        raise e
+                    else:
+                        raise ValueError(
+                            f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+                        )
+            return results
+
+        elif isinstance(inputs[0], tuple):
+            results = []
+            if not outpaths:
+                outpaths = [None] * len(inputs)
+            for (protein, ligand), outpath in zip(inputs, outpaths):
+                try:
+                    tag = protein.stem + "_" + ligand.stem
+                    if outpath:
+                        outpath = Path(outpath) / tag
+                    else:
+                        outpath = self.output_dir / tag
+                    if not outpath.exists():
+                        outpath.mkdir(parents=True)
+                    res = self._simulate_loop(protein, ligand, outpath)
+                    results.append(res)
+                except Exception as e:
+                    if failure_mode == "skip":
+                        logger.error(f"Error processing {tag}: {e}")
+                    elif failure_mode == "raise":
+                        raise e
+                    else:
+                        raise ValueError(
+                            f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
+                        )
+            return results
+
+        else:
+            raise NotImplementedError(
+                f"Cannot dispatch simulation on inputs of type {type(inputs[0])}"
+            )
 
     def _simulate_loop(
         self,

--- a/devtools/conda-envs/macos-latest/alchemy.yaml
+++ b/devtools/conda-envs/macos-latest/alchemy.yaml
@@ -31,7 +31,6 @@ dependencies:
   - openff-interchange =0.4.11
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
 
   # Data services
   - requests

--- a/devtools/conda-envs/macos-latest/all.yaml
+++ b/devtools/conda-envs/macos-latest/all.yaml
@@ -31,7 +31,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
 
   # Data services

--- a/devtools/conda-envs/macos-latest/cli.yaml
+++ b/devtools/conda-envs/macos-latest/cli.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-interchange =0.4.11
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
 
   # Data services
   - requests

--- a/devtools/conda-envs/macos-latest/data.yaml
+++ b/devtools/conda-envs/macos-latest/data.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - gufe =1.7.1
 
   # Data services

--- a/devtools/conda-envs/macos-latest/dataviz.yaml
+++ b/devtools/conda-envs/macos-latest/dataviz.yaml
@@ -29,7 +29,6 @@ dependencies:
   - openff-toolkit
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - gufe =1.7.1
 
   # Data services

--- a/devtools/conda-envs/macos-latest/docking.yaml
+++ b/devtools/conda-envs/macos-latest/docking.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - gufe =1.7.1
 
   # Data services

--- a/devtools/conda-envs/macos-latest/ml.yaml
+++ b/devtools/conda-envs/macos-latest/ml.yaml
@@ -29,7 +29,6 @@ dependencies:
   - openff-toolkit
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - gufe =1.7.1
 
   # Data services

--- a/devtools/conda-envs/macos-latest/modeling.yaml
+++ b/devtools/conda-envs/macos-latest/modeling.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-toolkit
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - gufe =1.7.1
 
   # Data services

--- a/devtools/conda-envs/macos-latest/simulation.yaml
+++ b/devtools/conda-envs/macos-latest/simulation.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-toolkit
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - gufe =1.7.1
 
   # Data services

--- a/devtools/conda-envs/macos-latest/spectrum.yaml
+++ b/devtools/conda-envs/macos-latest/spectrum.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-toolkit
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - gufe =1.7.1
 
   # Data services

--- a/devtools/conda-envs/macos-latest/workflows.yaml
+++ b/devtools/conda-envs/macos-latest/workflows.yaml
@@ -29,7 +29,6 @@ dependencies:
   - openff-toolkit
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - gufe =1.7.1
 
   # Data services

--- a/devtools/conda-envs/ubuntu-latest/alchemy.yaml
+++ b/devtools/conda-envs/ubuntu-latest/alchemy.yaml
@@ -32,7 +32,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
 
   # Data services

--- a/devtools/conda-envs/ubuntu-latest/all.yaml
+++ b/devtools/conda-envs/ubuntu-latest/all.yaml
@@ -31,7 +31,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1 # remove pin?
 
   # Data services

--- a/devtools/conda-envs/ubuntu-latest/cli.yaml
+++ b/devtools/conda-envs/ubuntu-latest/cli.yaml
@@ -31,7 +31,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
 
   # Data services

--- a/devtools/conda-envs/ubuntu-latest/data.yaml
+++ b/devtools/conda-envs/ubuntu-latest/data.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
   - gufe =1.7.1
 

--- a/devtools/conda-envs/ubuntu-latest/dataviz.yaml
+++ b/devtools/conda-envs/ubuntu-latest/dataviz.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
   - gufe =1.7.1
 

--- a/devtools/conda-envs/ubuntu-latest/docking.yaml
+++ b/devtools/conda-envs/ubuntu-latest/docking.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
   - gufe =1.7.1
 

--- a/devtools/conda-envs/ubuntu-latest/ml.yaml
+++ b/devtools/conda-envs/ubuntu-latest/ml.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
   - gufe =1.7.1
 

--- a/devtools/conda-envs/ubuntu-latest/modeling.yaml
+++ b/devtools/conda-envs/ubuntu-latest/modeling.yaml
@@ -31,7 +31,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
   - gufe =1.7.1
 

--- a/devtools/conda-envs/ubuntu-latest/simulation.yaml
+++ b/devtools/conda-envs/ubuntu-latest/simulation.yaml
@@ -31,7 +31,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
   - gufe =1.7.1
 

--- a/devtools/conda-envs/ubuntu-latest/spectrum.yaml
+++ b/devtools/conda-envs/ubuntu-latest/spectrum.yaml
@@ -31,7 +31,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
   - gufe =1.7.1
 

--- a/devtools/conda-envs/ubuntu-latest/workflows.yaml
+++ b/devtools/conda-envs/ubuntu-latest/workflows.yaml
@@ -30,7 +30,6 @@ dependencies:
   - openff-fragmenter
   - openff-forcefields >=2024.04.0
   - openeye-toolkits
-  - multimethod
   - scipy >=1.13.1
   - gufe =1.7.1
 

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -57,7 +57,6 @@ dependencies:
   - validators
   - pyyaml
   - sigfig
-  - multimethod
 
   # ml
   - pytorch


### PR DESCRIPTION
Closes #1288.

The `multimethod` library was used in four files purely as syntactic sugar for runtime type-based dispatch on `_dispatch` methods. It conflicts with Pydantic v2's `ModelMetaclass` (which tries to reconstruct `multimethod` descriptors via `multimethod.__new__()` without the required `func`), forcing every affected model to carry `model_config = ConfigDict(ignored_types=(multimethod,))`. Any new model that forgot it would silently break.

All dispatch is on the first element's type, so it is trivially replaceable with `isinstance`.

## Changes
- Replace each `@multimethod` / `@_dispatch.register` overload set with a single `isinstance`-dispatching `_dispatch` method (with an explicit `NotImplementedError` for unknown types and an empty-input short-circuit):
  - `docking/scorer.py` — `ChemGauss4Scorer`, `FINTScorer`, `GATScorer`, `E3MLModelScorer`, `SymClashScorer`
  - `dataviz/html_viz.py` — `HTMLVisualizer`
  - `dataviz/gif_viz.py` — `GIFVisualizer`
  - `simulation/simulate.py` — `VanillaMDSimulator`
- Remove the six `ignored_types=(multimethod,)` workarounds, and drop now-unused `ConfigDict` / `multimethod` / `Ligand` imports.
- Drop the `multimethod` conda dependency from all env files and `docs/requirements.yaml`.

The dispatch behavior is preserved 1:1 — each branch keeps the original body, and the re-dispatch calls (e.g. `Path` → `Complex`) still work since they route through the same `isinstance` method.

## Verification
- `python -m py_compile` passes on all four modules.
- AST check: each scorer class now has exactly one, undecorated `_dispatch`.
- Repo-wide `grep` confirms **no** remaining `multimethod` references (code, env, or docs).
- No tests referenced `multimethod` / `DispatchError` / `_dispatch` directly.
- (Full test suite requires the conda env; validated by CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)