### PR TITLE
[WIP] Feat/septop abfe protocols

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/cli.py
@@ -1,15 +1,32 @@
+import re
 import warnings
+
+# Patch warnings.showwarning instead of using filterwarnings.
+#
+# Third-party packages (notably pandas.core.nanops at module-level) call
+# warnings.simplefilter("always", DeprecationWarning) many times during import,
+# which repeatedly pushes an "always" entry to the front of the filter list and
+# overrides any "ignore" filters we add.  Patching showwarning is evaluated after
+# all filter logic and cannot be overridden by third-party filter manipulation.
+_SUPPRESSED_DEPRECATION_PATTERNS = re.compile(
+    r"builtin type \S+ has no __module__ attribute"
+    r"|Support for class-based `config` is deprecated"
+    r"|Partial charges have been provided, these will preferentially be used"
+)
+_orig_showwarning = warnings.showwarning
+
+
+def _showwarning(msg, cat, fname, lno, *args, **kwargs):
+    if issubclass(cat, (DeprecationWarning, UserWarning)) and _SUPPRESSED_DEPRECATION_PATTERNS.search(str(msg)):
+        return
+    _orig_showwarning(msg, cat, fname, lno, *args, **kwargs)
+
+
+warnings.showwarning = _showwarning
 
 from asapdiscovery.alchemy.cli.alchemy import alchemy
 from asapdiscovery.alchemy.cli.bespoke import bespoke
 from asapdiscovery.alchemy.cli.prep import prep
-
-# filter all openfe user charge warnings in the CLI
-warnings.filterwarnings(
-    action="ignore",
-    message="Partial charges have been provided, these will preferentially be used instead of generating new partial charges",
-    category=UserWarning,
-)
 
 alchemy.add_command(prep)
 alchemy.add_command(bespoke)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
@@ -1099,12 +1099,15 @@ def clean_result_network(network, console=None, ddg_outlier_threshold=15):
     # remove edges that have erroneously high DDG values
     results_complex = []
     results_solvent = []
+    results_combined = []  # SepTop/ABFE: both legs handled internally
 
     for edge_result in denand_results:
         if edge_result.phase == "complex":
             results_complex.append(edge_result)
         elif edge_result.phase == "solvent":
             results_solvent.append(edge_result)
+        elif edge_result.phase == "combined":
+            results_combined.append(edge_result)
         else:
             raise ValueError(
                 f"Edge phase {edge_result.phase} not recognized for edge {edge_result}"
@@ -1127,6 +1130,14 @@ def clean_result_network(network, console=None, ddg_outlier_threshold=15):
                     results_not_overly_large.append(res_complex)
                 else:
                     large_edge_removal_counter += 1
+
+    # Combined-phase results already contain the full ΔΔG / ΔG_bind; apply the
+    # outlier threshold directly on the estimate magnitude.
+    for result in results_combined:
+        if abs(result.estimate.magnitude) < ddg_outlier_threshold:
+            results_not_overly_large.append(result)
+        else:
+            large_edge_removal_counter += 1
 
     # done! let's repack everything.
     if console:

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
@@ -407,17 +407,41 @@ class _BaseResults(_SchemaBaseFrozen):
         for transforms in raw_results.values():
             phases = {t.phase for t in transforms}
             if "combined" in phases:
-                # SepTopProtocol: estimate IS already ΔΔG (complex − solvent computed
-                # internally); use it directly without a second leg.
+                # Single-Transformation protocols return the final free energy directly
+                # from get_estimate() — no leg subtraction required.
+                # SepTop → ΔΔG_bind (RBFE); AbsoluteBinding → ΔG_bind (ABFE).
                 combined = transforms[0]
-                result = Measurement(
-                    labelA=combined.ligand_a,
-                    labelB=combined.ligand_b,
-                    DG=combined.estimate,
-                    uncertainty=combined.uncertainty,
-                    computational=True,
-                    source="calculated",
-                )
+                if combined.ligand_b is None:
+                    # ABFE: absolute ΔG_bind
+                    try:
+                        from cinnabar import AbsoluteMeasurement
+
+                        result = AbsoluteMeasurement(
+                            label=combined.ligand_a,
+                            DG=combined.estimate,
+                            uncertainty=combined.uncertainty,
+                            computational=True,
+                            source="calculated",
+                        )
+                    except ImportError:
+                        result = Measurement(
+                            labelA=combined.ligand_a,
+                            labelB="__vacuum__",
+                            DG=combined.estimate,
+                            uncertainty=combined.uncertainty,
+                            computational=True,
+                            source="calculated",
+                        )
+                else:
+                    # SepTop (and similar): relative ΔΔG_bind
+                    result = Measurement(
+                        labelA=combined.ligand_a,
+                        labelB=combined.ligand_b,
+                        DG=combined.estimate,
+                        uncertainty=combined.uncertainty,
+                        computational=True,
+                        source="calculated",
+                    )
             else:
                 leg1, leg2 = transforms
                 complex_leg: TransformationResult = (
@@ -803,48 +827,32 @@ class FreeEnergyCalculationNetwork(_FreeEnergyBase):
                     )
                     transformations.append(transformation)
 
-        # node-based (ABFE) protocols: one complex + one solvent Transformation per ligand
+        # node-based (ABFE) protocols: one Transformation per ligand.
+        # AbsoluteBindingProtocol (and similar) runs both complex and solvent legs
+        # internally from a single Transformation and returns ΔG_bind directly from
+        # get_estimate().  Its _validate_endstates() requires ProteinComponent in both
+        # stateA and stateB, so stateB is the apo protein (no ligand), not a bare
+        # solvent box.
         for protocol_name in self._protocols_for_node():
             base_settings = self.protocol_settings[protocol_name]
 
             for ligand in ligand_network.nodes:
-                node_protocol = build_protocol(protocol_name, base_settings)
-
-                # complex leg: ligand disappears in the protein-bound environment
-                sys_a_complex = openfe.ChemicalSystem(
+                sys_a = openfe.ChemicalSystem(
                     {"ligand": ligand, "protein": receptor, "solvent": solvent},
-                    name=f"{ligand.name}_complex",
+                    name=f"{ligand.name}_bound",
                 )
-                sys_b_complex = openfe.ChemicalSystem(
+                # stateB: ligand is annihilated; protein + solvent remain.
+                sys_b = openfe.ChemicalSystem(
                     {"protein": receptor, "solvent": solvent},
-                    name=f"{ligand.name}_complex_vacuum",
+                    name=f"{ligand.name}_apo",
                 )
                 transformations.append(
                     openfe.Transformation(
-                        stateA=sys_a_complex,
-                        stateB=sys_b_complex,
+                        stateA=sys_a,
+                        stateB=sys_b,
                         mapping=None,
                         protocol=build_protocol(protocol_name, base_settings),
-                        name=f"{ligand.name}_complex_{protocol_name}",
-                    )
-                )
-
-                # solvent leg: ligand disappears in bulk solvent (hydration correction)
-                sys_a_solvent = openfe.ChemicalSystem(
-                    {"ligand": ligand, "solvent": solvent},
-                    name=f"{ligand.name}_solvent",
-                )
-                sys_b_solvent = openfe.ChemicalSystem(
-                    {"solvent": solvent},
-                    name=f"{ligand.name}_solvent_vacuum",
-                )
-                transformations.append(
-                    openfe.Transformation(
-                        stateA=sys_a_solvent,
-                        stateB=sys_b_solvent,
-                        mapping=None,
-                        protocol=build_protocol(protocol_name, base_settings),
-                        name=f"{ligand.name}_solvent_{protocol_name}",
+                        name=f"{ligand.name}_{protocol_name}",
                     )
                 )
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
@@ -341,11 +341,13 @@ class _BaseResults(_SchemaBaseFrozen):
         Combine the solvent and complex phases of each transformation into cinnabar
         measurement objects.
 
-        For edge-based (RBFE) results (``ligand_b`` is set) a
-        ``cinnabar.Measurement`` (relative ΔΔG) is produced from
-        ``ΔG_complex − ΔG_solvent``.  For node-based (ABFE) results
-        (``ligand_b is None``) a ``cinnabar.AbsoluteMeasurement`` (absolute ΔG)
-        is produced from the same combination.
+        For edge-based (RBFE) results (``ligand_b`` is set) a relative
+        ``cinnabar.Measurement`` (ΔΔG) is produced from ``ΔG_complex − ΔG_solvent``.
+        For node-based (ABFE) results (``ligand_b is None``) an *absolute*
+        ``cinnabar.Measurement`` (ΔG) is produced from the same combination,
+        using cinnabar's idiomatic representation of an absolute value: a
+        ``Measurement`` anchored at a true-ground ``ReferenceState`` so it can
+        serve as an anchor in a combined RBFE+ABFE FEMap.
 
         Args:
             protocol: If provided (including ``None`` for legacy results), only
@@ -355,13 +357,14 @@ class _BaseResults(_SchemaBaseFrozen):
                 same edge are never merged.
 
         Returns:
-            A list of ``cinnabar.Measurement`` and/or ``cinnabar.AbsoluteMeasurement``
-            objects made from the combined solvent and complex phases.
+            A list of ``cinnabar.Measurement`` objects (relative for RBFE,
+            absolute — anchored at a ``ReferenceState`` — for ABFE) made from the
+            combined solvent and complex phases.
         """
         from collections import defaultdict
 
         import numpy as np
-        from cinnabar import Measurement
+        from cinnabar import Measurement, ReferenceState
 
         if protocol == "__all__":
             results = self.results
@@ -412,26 +415,17 @@ class _BaseResults(_SchemaBaseFrozen):
                 # SepTop → ΔΔG_bind (RBFE); AbsoluteBinding → ΔG_bind (ABFE).
                 combined = transforms[0]
                 if combined.ligand_b is None:
-                    # ABFE: absolute ΔG_bind
-                    try:
-                        from cinnabar import AbsoluteMeasurement
-
-                        result = AbsoluteMeasurement(
-                            label=combined.ligand_a,
-                            DG=combined.estimate,
-                            uncertainty=combined.uncertainty,
-                            computational=True,
-                            source="calculated",
-                        )
-                    except ImportError:
-                        result = Measurement(
-                            labelA=combined.ligand_a,
-                            labelB="__vacuum__",
-                            DG=combined.estimate,
-                            uncertainty=combined.uncertainty,
-                            computational=True,
-                            source="calculated",
-                        )
+                    # ABFE: absolute ΔG_bind — expressed as a Measurement relative to
+                    # a true-ground ReferenceState (cinnabar's idiomatic absolute value)
+                    # so it can anchor a combined RBFE+ABFE FEMap.
+                    result = Measurement(
+                        labelA=ReferenceState(),
+                        labelB=combined.ligand_a,
+                        DG=combined.estimate,
+                        uncertainty=combined.uncertainty,
+                        computational=True,
+                        source="calculated",
+                    )
                 else:
                     # SepTop (and similar): relative ΔΔG_bind
                     result = Measurement(
@@ -456,29 +450,17 @@ class _BaseResults(_SchemaBaseFrozen):
                 )
 
                 if leg1.ligand_b is None:
-                    # ABFE: absolute ΔG_bind — use cinnabar AbsoluteMeasurement so it
-                    # can serve as an anchor in a combined RBFE+ABFE FEMap
-                    try:
-                        from cinnabar import AbsoluteMeasurement
-
-                        result = AbsoluteMeasurement(
-                            label=leg1.ligand_a,
-                            DG=dg,
-                            uncertainty=uncertainty,
-                            computational=True,
-                            source="calculated",
-                        )
-                    except ImportError:
-                        # fall back to a relative measurement with a sentinel second label
-                        # if the installed cinnabar version predates AbsoluteMeasurement
-                        result = Measurement(
-                            labelA=leg1.ligand_a,
-                            labelB="__vacuum__",
-                            DG=dg,
-                            uncertainty=uncertainty,
-                            computational=True,
-                            source="calculated",
-                        )
+                    # ABFE: absolute ΔG_bind — expressed as a Measurement relative to
+                    # a true-ground ReferenceState (cinnabar's idiomatic absolute value)
+                    # so it can serve as an anchor in a combined RBFE+ABFE FEMap.
+                    result = Measurement(
+                        labelA=ReferenceState(),
+                        labelB=leg1.ligand_a,
+                        DG=dg,
+                        uncertainty=uncertainty,
+                        computational=True,
+                        source="calculated",
+                    )
                 else:
                     # RBFE: relative ΔΔG_bind
                     result = Measurement(

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
@@ -6,6 +6,7 @@ import gufe
 import openfe
 from alchemiscale import ScopedKey
 from gufe import settings
+from gufe.settings.models import SettingsBaseModel
 from gufe.settings.typing import (
     GufeQuantity,
     KCalPerMolQuantity,
@@ -26,7 +27,12 @@ from pydantic import (
 from ._util import check_ligand_series_uniqueness_and_names
 from .base import _SchemaBase, _SchemaBaseFrozen
 from .network import NetworkPlanner, PlannedNetwork
-from .protocols import available_protocols, build_protocol, default_protocol_settings
+from .protocols import (
+    available_protocols,
+    build_protocol,
+    default_protocol_settings,
+    is_node_protocol,
+)
 
 if TYPE_CHECKING:
     from cinnabar import FEMap
@@ -120,6 +126,7 @@ class AdaptiveSettings(_SchemaBase):
         mapping: "LigandAtomMapping",
         settings: "gufe.settings.Settings",
         base_sampling_length: OFFUnit.Quantity,
+        sim_settings_attr: str = "simulation_settings",
     ) -> "gufe.settings.Settings":
         """
         It's advisable to increase simulation time on edges that are expected to be less reliable. There
@@ -128,6 +135,12 @@ class AdaptiveSettings(_SchemaBase):
         If the edge scoring (computed using `scorer_method`) is below the `adaptive_sampling_threshold` the
         simulation time is multiplied by `adaptive_sampling_multiplier`. Just to be sure, we use the base
         protocol's sampling time and not the provided edge protocol sampling time as a base value.
+
+        ``sim_settings_attr`` names the attribute on ``settings`` that holds the
+        simulation-time sub-settings (e.g. ``"simulation_settings"`` for RFE, or
+        ``"complex_simulation_settings"`` / ``"solvent_simulation_settings"`` for
+        protocols with per-leg settings such as ``SepTopProtocol`` or
+        ``AbsoluteBindingProtocol``).
 
         Mutates and returns the (editable) protocol settings.
         """
@@ -140,7 +153,7 @@ class AdaptiveSettings(_SchemaBase):
                 f"Atom mapping scorer {scorer_method} not recognized; use one of `default_lomap`, `default_perses`."
             )
         if scorer(mapping) < self.adaptive_sampling_threshold:
-            settings.simulation_settings.production_length = (
+            getattr(settings, sim_settings_attr).production_length = (
                 base_sampling_length * self.adaptive_sampling_multiplier
             )
         return settings
@@ -149,6 +162,7 @@ class AdaptiveSettings(_SchemaBase):
         self,
         leg: str,
         settings: "gufe.settings.Settings",
+        solv_settings_attr: str = "solvation_settings",
     ) -> "gufe.settings.Settings":
         """
         Certain water box shapes (such as dodecahedron) are able to handle slightly smaller padding size
@@ -156,12 +170,19 @@ class AdaptiveSettings(_SchemaBase):
         this method applies the specified padding per phase (`solvent_padding_solvated` or
         `solvent_padding_complex`, resp.).
 
+        ``solv_settings_attr`` names the solvation sub-settings attribute to mutate
+        (e.g. ``"solvation_settings"`` for RFE, or ``"complex_solvation_settings"`` /
+        ``"solvent_solvation_settings"`` for protocols with per-leg settings such as
+        ``SepTopProtocol`` or ``AbsoluteBindingProtocol``).
+
         Mutates and returns the (editable) protocol settings.
         """
-        if leg == "solvent":
-            settings.solvation_settings.solvent_padding = self.solvent_padding_solvated
-        else:
-            settings.solvation_settings.solvent_padding = self.solvent_padding_complex
+        padding = (
+            self.solvent_padding_solvated
+            if leg == "solvent"
+            else self.solvent_padding_complex
+        )
+        getattr(settings, solv_settings_attr).solvent_padding = padding
         return settings
 
     def apply_settings(
@@ -181,17 +202,20 @@ class AdaptiveSettings(_SchemaBase):
         (``unfrozen_copy``) settings object which is mutated in place.
 
         Adaptive settings are only applied where the settings expose the relevant
-        fields. ``RelativeHybridTopologyProtocol`` settings carry
+        fields. ``RelativeHybridTopologyProtocol`` settings carry a flat
         ``simulation_settings`` (sampling length) and ``solvation_settings``
-        (solvent padding); non-equilibrium protocols (e.g. feflow's
-        ``NonEquilibriumCyclingProtocol``) have no ``simulation_settings`` so
-        adaptive sampling is skipped for them with a warning.
+        (solvent padding). ``SepTopProtocol`` and ``AbsoluteBindingProtocol``
+        use per-leg split attributes (``complex_simulation_settings`` /
+        ``solvent_simulation_settings`` and the equivalent solvation attributes).
+        Non-equilibrium protocols (e.g. feflow's ``NonEquilibriumCyclingProtocol``)
+        have no ``simulation_settings`` so adaptive sampling is skipped with a warning.
         """
-        # double the simulation time if requested (RFE-style protocols only)
+        # double the simulation time if requested
         if self.adaptive_sampling:
             if hasattr(edge_settings, "simulation_settings") and hasattr(
                 base_settings, "simulation_settings"
             ):
+                # flat settings: RelativeHybridTopologyProtocol style
                 base_sampling_length = (
                     base_settings.simulation_settings.production_length
                 )
@@ -199,22 +223,48 @@ class AdaptiveSettings(_SchemaBase):
                     network_scorer, mapping, edge_settings, base_sampling_length
                 )
             else:
-                warnings.warn(
-                    "adaptive_sampling requested but protocol settings "
-                    f"{type(edge_settings).__name__} have no `simulation_settings`; "
-                    "skipping adaptive sampling for this protocol."
-                )
+                # split per-leg settings: SepTopProtocol / AbsoluteBindingProtocol style
+                leg_sim_attr = f"{leg}_simulation_settings"
+                if hasattr(edge_settings, leg_sim_attr) and hasattr(
+                    base_settings, leg_sim_attr
+                ):
+                    base_sampling_length = getattr(
+                        base_settings, leg_sim_attr
+                    ).production_length
+                    edge_settings = self.get_adapted_sampling_settings(
+                        network_scorer,
+                        mapping,
+                        edge_settings,
+                        base_sampling_length,
+                        sim_settings_attr=leg_sim_attr,
+                    )
+                else:
+                    warnings.warn(
+                        "adaptive_sampling requested but protocol settings "
+                        f"{type(edge_settings).__name__} have no `simulation_settings` "
+                        f"or `{leg}_simulation_settings`; "
+                        "skipping adaptive sampling for this protocol."
+                    )
 
         # adjust solvent padding per phase if requested
         if self.adaptive_solvent_padding:
             if hasattr(edge_settings, "solvation_settings"):
+                # flat settings: RelativeHybridTopologyProtocol style
                 edge_settings = self.get_adapted_solvent_settings(leg, edge_settings)
             else:
-                warnings.warn(
-                    "adaptive_solvent_padding requested but protocol settings "
-                    f"{type(edge_settings).__name__} have no `solvation_settings`; "
-                    "skipping adaptive solvent padding for this protocol."
-                )
+                # split per-leg settings: SepTopProtocol / AbsoluteBindingProtocol style
+                leg_solv_attr = f"{leg}_solvation_settings"
+                if hasattr(edge_settings, leg_solv_attr):
+                    edge_settings = self.get_adapted_solvent_settings(
+                        leg, edge_settings, solv_settings_attr=leg_solv_attr
+                    )
+                else:
+                    warnings.warn(
+                        "adaptive_solvent_padding requested but protocol settings "
+                        f"{type(edge_settings).__name__} have no `solvation_settings` "
+                        f"or `{leg}_solvation_settings`; "
+                        "skipping adaptive solvent padding for this protocol."
+                    )
 
         return edge_settings
 
@@ -229,8 +279,10 @@ class TransformationResult(_SchemaBaseFrozen):
     ligand_a: str = Field(
         ..., description="The name of the ligand in state A of the transformation."
     )
-    ligand_b: str = Field(
-        ..., description="The name of the ligand in state B of the transformation."
+    ligand_b: Optional[str] = Field(
+        None,
+        description="The name of the ligand in state B of the transformation. "
+        "``None`` for node-based (ABFE) results where state B contains no ligand.",
     )
     phase: Literal["complex", "solvent"] = Field(
         ..., description="The phase of the transformation."
@@ -250,6 +302,8 @@ class TransformationResult(_SchemaBaseFrozen):
 
     def name(self):
         """Make a name for this transformation based on the names of the ligands."""
+        if self.ligand_b is None:
+            return self.ligand_a
         return "-".join([self.ligand_a, self.ligand_b])
 
 
@@ -278,7 +332,14 @@ class _BaseResults(_SchemaBaseFrozen):
 
     def to_cinnabar_measurements(self, protocol: Optional[str] = "__all__"):
         """
-        For the given set of results combine the solvent and complex phases to make a list of cinnabar RelativeMeasurements
+        Combine the solvent and complex phases of each transformation into cinnabar
+        measurement objects.
+
+        For edge-based (RBFE) results (``ligand_b`` is set) a
+        ``cinnabar.Measurement`` (relative ΔΔG) is produced from
+        ``ΔG_complex − ΔG_solvent``.  For node-based (ABFE) results
+        (``ligand_b is None``) a ``cinnabar.AbsoluteMeasurement`` (absolute ΔG)
+        is produced from the same combination.
 
         Args:
             protocol: If provided (including ``None`` for legacy results), only
@@ -288,7 +349,8 @@ class _BaseResults(_SchemaBaseFrozen):
                 same edge are never merged.
 
         Returns:
-            A list of RelativeMeasurements made from the combined solvent and complex phases.
+            A list of ``cinnabar.Measurement`` and/or ``cinnabar.AbsoluteMeasurement``
+            objects made from the combined solvent and complex phases.
         """
         from collections import defaultdict
 
@@ -333,17 +395,45 @@ class _BaseResults(_SchemaBaseFrozen):
             solvent_leg: TransformationResult = (
                 leg1 if leg1.phase == "solvent" else leg2
             )
-            result = Measurement(
-                labelA=leg1.ligand_a,
-                labelB=leg1.ligand_b,
-                DG=(complex_leg.estimate - solvent_leg.estimate),
-                # propagate errors
-                uncertainty=np.sqrt(
-                    complex_leg.uncertainty**2 + solvent_leg.uncertainty**2
-                ),
-                computational=True,
-                source="calculated",
+            dg = complex_leg.estimate - solvent_leg.estimate
+            uncertainty = np.sqrt(
+                complex_leg.uncertainty**2 + solvent_leg.uncertainty**2
             )
+
+            if leg1.ligand_b is None:
+                # ABFE: absolute ΔG_bind — use cinnabar AbsoluteMeasurement so it
+                # can serve as an anchor in a combined RBFE+ABFE FEMap
+                try:
+                    from cinnabar import AbsoluteMeasurement
+
+                    result = AbsoluteMeasurement(
+                        label=leg1.ligand_a,
+                        DG=dg,
+                        uncertainty=uncertainty,
+                        computational=True,
+                        source="calculated",
+                    )
+                except ImportError:
+                    # fall back to a relative measurement with a sentinel second label
+                    # if the installed cinnabar version predates AbsoluteMeasurement
+                    result = Measurement(
+                        labelA=leg1.ligand_a,
+                        labelB="__vacuum__",
+                        DG=dg,
+                        uncertainty=uncertainty,
+                        computational=True,
+                        source="calculated",
+                    )
+            else:
+                # RBFE: relative ΔΔG_bind
+                result = Measurement(
+                    labelA=leg1.ligand_a,
+                    labelB=leg1.ligand_b,
+                    DG=dg,
+                    uncertainty=uncertainty,
+                    computational=True,
+                    source="calculated",
+                )
             all_results.append(result)
         return all_results
 
@@ -460,7 +550,7 @@ class _FreeEnergyBase(_SchemaBase):
             return value
         decoded = {}
         for name, settings_obj in value.items():
-            if isinstance(settings_obj, settings.Settings):
+            if isinstance(settings_obj, SettingsBaseModel):
                 decoded[name] = settings_obj
             else:
                 decoded[name] = json.loads(
@@ -579,17 +669,26 @@ class FreeEnergyCalculationNetwork(_FreeEnergyBase):
 
         Driven by ``protocol_strategy``:
 
-        - ``"all"``: every configured protocol is applied to every edge, i.e. one
-          ``Transformation`` per edge per protocol.
+        - ``"all"``: every configured *edge-based* protocol is applied to every
+          edge.  Node-based protocols (ABFE) are excluded — they are applied per
+          ligand node in :meth:`_protocols_for_node`.
 
         Future strategies (e.g. assigning a single protocol per edge based on edge
         properties) can use ``mapping`` to make that decision here.
         """
         if self.protocol_strategy == "all":
-            return list(self.protocol)
+            return [p for p in self.protocol if not is_node_protocol(p)]
         raise NotImplementedError(
             f"protocol_strategy {self.protocol_strategy!r} is not implemented."
         )
+
+    def _protocols_for_node(self) -> list[str]:
+        """Return the node-based (ABFE) protocols to apply to each ligand node.
+
+        Node-based protocols generate one ``Transformation`` per ligand rather
+        than per ligand pair, so they are handled separately from edge protocols.
+        """
+        return [p for p in self.protocol if is_node_protocol(p)]
 
     def to_alchemical_network(self) -> openfe.AlchemicalNetwork:
         """
@@ -668,6 +767,51 @@ class FreeEnergyCalculationNetwork(_FreeEnergyBase):
                         name=f"{system_a.name}_{system_b.name}_{protocol_name}",
                     )
                     transformations.append(transformation)
+
+        # node-based (ABFE) protocols: one complex + one solvent Transformation per ligand
+        for protocol_name in self._protocols_for_node():
+            base_settings = self.protocol_settings[protocol_name]
+
+            for ligand in ligand_network.nodes:
+                node_protocol = build_protocol(protocol_name, base_settings)
+
+                # complex leg: ligand disappears in the protein-bound environment
+                sys_a_complex = openfe.ChemicalSystem(
+                    {"ligand": ligand, "protein": receptor, "solvent": solvent},
+                    name=f"{ligand.name}_complex",
+                )
+                sys_b_complex = openfe.ChemicalSystem(
+                    {"protein": receptor, "solvent": solvent},
+                    name=f"{ligand.name}_complex_vacuum",
+                )
+                transformations.append(
+                    openfe.Transformation(
+                        stateA=sys_a_complex,
+                        stateB=sys_b_complex,
+                        mapping=None,
+                        protocol=build_protocol(protocol_name, base_settings),
+                        name=f"{ligand.name}_complex_{protocol_name}",
+                    )
+                )
+
+                # solvent leg: ligand disappears in bulk solvent (hydration correction)
+                sys_a_solvent = openfe.ChemicalSystem(
+                    {"ligand": ligand, "solvent": solvent},
+                    name=f"{ligand.name}_solvent",
+                )
+                sys_b_solvent = openfe.ChemicalSystem(
+                    {"solvent": solvent},
+                    name=f"{ligand.name}_solvent_vacuum",
+                )
+                transformations.append(
+                    openfe.Transformation(
+                        stateA=sys_a_solvent,
+                        stateB=sys_b_solvent,
+                        mapping=None,
+                        protocol=build_protocol(protocol_name, base_settings),
+                        name=f"{ligand.name}_solvent_{protocol_name}",
+                    )
+                )
 
         return openfe.AlchemicalNetwork(edges=transformations, name=self.dataset_name)
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
@@ -32,6 +32,7 @@ from .protocols import (
     build_protocol,
     default_protocol_settings,
     is_node_protocol,
+    needs_solvent_leg,
 )
 
 if TYPE_CHECKING:
@@ -284,8 +285,13 @@ class TransformationResult(_SchemaBaseFrozen):
         description="The name of the ligand in state B of the transformation. "
         "``None`` for node-based (ABFE) results where state B contains no ligand.",
     )
-    phase: Literal["complex", "solvent"] = Field(
-        ..., description="The phase of the transformation."
+    phase: Literal["complex", "solvent", "combined"] = Field(
+        ...,
+        description=(
+            "The phase of the transformation.  ``'combined'`` is used for protocols "
+            "that handle both complex and solvent legs internally and return ΔΔG "
+            "directly (e.g. SepTopProtocol)."
+        ),
     )
     estimate: KCalPerMolQuantity = Field(
         ..., description="The average estimate of this transformation in kcal/mol"
@@ -367,73 +373,98 @@ class _BaseResults(_SchemaBaseFrozen):
         for result in results:
             raw_results[(result.protocol, result.name())].append(result)
 
-        # make sure we have a solvent and complex phase for each result
+        # Validate phase completeness and separate "combined" (SepTop) edges from
+        # two-leg (RFE/NEQ/ABFE) edges.
         keys_to_remove = []
         for key, transforms in raw_results.items():
             _, name = key
-            missing_phase = {"complex", "solvent"} - {t.phase for t in transforms}
-            if missing_phase:
-                warnings.warn(
-                    f"The transformation {name} is missing simulated legs in the following phases {missing_phase}; removing"
-                )
-                keys_to_remove.append(key)
-            if len(transforms) > 2:
-                # We have too many simulations for this transform
-                raise RuntimeError(
-                    f"The transformation {name} has too many simulated legs, found the following phases {[t.phase for t in transforms]} expected complex and solvent."
-                )
+            phases = {t.phase for t in transforms}
+            if "combined" in phases:
+                # Single-Transformation protocols (e.g. SepTopProtocol) return ΔΔG
+                # directly; expect exactly one result per edge.
+                if len(transforms) != 1:
+                    raise RuntimeError(
+                        f"The transformation {name} has {len(transforms)} results with "
+                        f"phase='combined'; expected exactly one."
+                    )
+            else:
+                missing_phase = {"complex", "solvent"} - phases
+                if missing_phase:
+                    warnings.warn(
+                        f"The transformation {name} is missing simulated legs in the following phases {missing_phase}; removing"
+                    )
+                    keys_to_remove.append(key)
+                elif len(transforms) > 2:
+                    raise RuntimeError(
+                        f"The transformation {name} has too many simulated legs, found the following phases {[t.phase for t in transforms]} expected complex and solvent."
+                    )
 
         for key in keys_to_remove:
             raw_results.pop(key)
 
         # make the cinnabar data
         all_results = []
-        for leg1, leg2 in raw_results.values():
-            complex_leg: TransformationResult = (
-                leg1 if leg1.phase == "complex" else leg2
-            )
-            solvent_leg: TransformationResult = (
-                leg1 if leg1.phase == "solvent" else leg2
-            )
-            dg = complex_leg.estimate - solvent_leg.estimate
-            uncertainty = np.sqrt(
-                complex_leg.uncertainty**2 + solvent_leg.uncertainty**2
-            )
-
-            if leg1.ligand_b is None:
-                # ABFE: absolute ΔG_bind — use cinnabar AbsoluteMeasurement so it
-                # can serve as an anchor in a combined RBFE+ABFE FEMap
-                try:
-                    from cinnabar import AbsoluteMeasurement
-
-                    result = AbsoluteMeasurement(
-                        label=leg1.ligand_a,
-                        DG=dg,
-                        uncertainty=uncertainty,
-                        computational=True,
-                        source="calculated",
-                    )
-                except ImportError:
-                    # fall back to a relative measurement with a sentinel second label
-                    # if the installed cinnabar version predates AbsoluteMeasurement
-                    result = Measurement(
-                        labelA=leg1.ligand_a,
-                        labelB="__vacuum__",
-                        DG=dg,
-                        uncertainty=uncertainty,
-                        computational=True,
-                        source="calculated",
-                    )
-            else:
-                # RBFE: relative ΔΔG_bind
+        for transforms in raw_results.values():
+            phases = {t.phase for t in transforms}
+            if "combined" in phases:
+                # SepTopProtocol: estimate IS already ΔΔG (complex − solvent computed
+                # internally); use it directly without a second leg.
+                combined = transforms[0]
                 result = Measurement(
-                    labelA=leg1.ligand_a,
-                    labelB=leg1.ligand_b,
-                    DG=dg,
-                    uncertainty=uncertainty,
+                    labelA=combined.ligand_a,
+                    labelB=combined.ligand_b,
+                    DG=combined.estimate,
+                    uncertainty=combined.uncertainty,
                     computational=True,
                     source="calculated",
                 )
+            else:
+                leg1, leg2 = transforms
+                complex_leg: TransformationResult = (
+                    leg1 if leg1.phase == "complex" else leg2
+                )
+                solvent_leg: TransformationResult = (
+                    leg1 if leg1.phase == "solvent" else leg2
+                )
+                dg = complex_leg.estimate - solvent_leg.estimate
+                uncertainty = np.sqrt(
+                    complex_leg.uncertainty**2 + solvent_leg.uncertainty**2
+                )
+
+                if leg1.ligand_b is None:
+                    # ABFE: absolute ΔG_bind — use cinnabar AbsoluteMeasurement so it
+                    # can serve as an anchor in a combined RBFE+ABFE FEMap
+                    try:
+                        from cinnabar import AbsoluteMeasurement
+
+                        result = AbsoluteMeasurement(
+                            label=leg1.ligand_a,
+                            DG=dg,
+                            uncertainty=uncertainty,
+                            computational=True,
+                            source="calculated",
+                        )
+                    except ImportError:
+                        # fall back to a relative measurement with a sentinel second label
+                        # if the installed cinnabar version predates AbsoluteMeasurement
+                        result = Measurement(
+                            labelA=leg1.ligand_a,
+                            labelB="__vacuum__",
+                            DG=dg,
+                            uncertainty=uncertainty,
+                            computational=True,
+                            source="calculated",
+                        )
+                else:
+                    # RBFE: relative ΔΔG_bind
+                    result = Measurement(
+                        labelA=leg1.ligand_a,
+                        labelB=leg1.ligand_b,
+                        DG=dg,
+                        uncertainty=uncertainty,
+                        computational=True,
+                        source="calculated",
+                    )
             all_results.append(result)
         return all_results
 
@@ -717,7 +748,11 @@ class FreeEnergyCalculationNetwork(_FreeEnergyBase):
                         base_force_field=base_settings.forcefield_settings.small_molecule_forcefield,
                     )
 
-                for leg in ["solvent", "complex"]:
+                # Protocols that handle both legs internally (e.g. SepTopProtocol)
+                # require a single complex-phase Transformation only; their
+                # get_estimate() already returns ΔΔG = ΔG_complex − ΔG_solvent.
+                legs = ["complex"] if not needs_solvent_leg(protocol_name) else ["solvent", "complex"]
+                for leg in legs:
                     sys_a_dict = {"ligand": mapping.componentA, "solvent": solvent}
                     sys_b_dict = {"ligand": mapping.componentB, "solvent": solvent}
                     if leg == "complex":

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/protocols.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/protocols.py
@@ -65,6 +65,7 @@ PROTOCOL_REGISTRY: dict[str, _ProtocolRegistration] = {
         protocol_class="AbsoluteBindingProtocol",
         package="openfe",
         is_node_protocol=True,
+        needs_solvent_leg=False,
     ),
 }
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/protocols.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/protocols.py
@@ -26,6 +26,9 @@ class _ProtocolRegistration(NamedTuple):
     protocol_class: str
     #: The distribution that must be installed to use this protocol (for error messages).
     package: str
+    #: True for node-based protocols (ABFE: one Transformation per ligand, no mapping);
+    #: False for edge-based protocols (RBFE: one Transformation per ligand *pair*).
+    is_node_protocol: bool = False
 
 
 #: Index of the alchemical protocols ASAP-Alchemy knows how to build.
@@ -35,6 +38,11 @@ PROTOCOL_REGISTRY: dict[str, _ProtocolRegistration] = {
     "RelativeHybridTopologyProtocol": _ProtocolRegistration(
         module="openfe.protocols.openmm_rfe",
         protocol_class="RelativeHybridTopologyProtocol",
+        package="openfe",
+    ),
+    "SepTopProtocol": _ProtocolRegistration(
+        module="openfe.protocols.openmm_septop",
+        protocol_class="SepTopProtocol",
         package="openfe",
     ),
     "NonEquilibriumCyclingProtocol": _ProtocolRegistration(
@@ -47,7 +55,32 @@ PROTOCOL_REGISTRY: dict[str, _ProtocolRegistration] = {
         protocol_class="FahNonEquilibriumCyclingProtocol",
         package="alchemiscale-fah",
     ),
+    "AbsoluteBindingProtocol": _ProtocolRegistration(
+        module="openfe.protocols.openmm_afe",
+        protocol_class="AbsoluteBindingProtocol",
+        package="openfe",
+        is_node_protocol=True,
+    ),
 }
+
+
+def is_node_protocol(name: str) -> bool:
+    """Return ``True`` if ``name`` is a node-based (ABFE) protocol.
+
+    Node-based protocols generate one ``Transformation`` per *ligand* (no
+    partner ligand and no atom mapping). Edge-based protocols generate one
+    ``Transformation`` per *ligand pair*.
+
+    Raises:
+        KeyError: If ``name`` is not a registered protocol.
+    """
+    try:
+        return PROTOCOL_REGISTRY[name].is_node_protocol
+    except KeyError:
+        raise KeyError(
+            f"Unknown protocol {name!r}; available protocols are "
+            f"{available_protocols()}."
+        )
 
 
 def available_protocols() -> list[str]:
@@ -119,10 +152,56 @@ def _asap_relative_hybrid_topology_settings() -> "Settings":
     return protocol_settings
 
 
+def _asap_septop_settings() -> "Settings":
+    """ASAP-tuned default settings for ``SepTopProtocol``.
+
+    Applies the same force-field and thermodynamic conditions as the RFE defaults
+    (openff-2.2.0, 298.15 K / 1 bar) and limits to a single protocol repeat, while
+    leaving simulation lengths and lambda schedules at the openfe upstream defaults.
+    """
+    from openff.units import unit as OFFUnit
+
+    protocol_class = get_protocol_class("SepTopProtocol")
+    protocol_settings = protocol_class.default_settings().unfrozen_copy()
+
+    protocol_settings.forcefield_settings.small_molecule_forcefield = (
+        "openff-2.2.0.offxml"
+    )
+    protocol_settings.thermo_settings.temperature = 298.15 * OFFUnit.kelvin
+    protocol_settings.thermo_settings.pressure = 1 * OFFUnit.bar
+    protocol_settings.protocol_repeats = 1
+
+    return protocol_settings
+
+
+def _asap_absolute_binding_settings() -> "Settings":
+    """ASAP-tuned default settings for ``AbsoluteBindingProtocol``.
+
+    Applies the same force-field and thermodynamic conditions as the RFE defaults
+    and limits to a single protocol repeat. Simulation lengths and lambda schedules
+    are left at the openfe upstream defaults.
+    """
+    from openff.units import unit as OFFUnit
+
+    protocol_class = get_protocol_class("AbsoluteBindingProtocol")
+    protocol_settings = protocol_class.default_settings().unfrozen_copy()
+
+    protocol_settings.forcefield_settings.small_molecule_forcefield = (
+        "openff-2.2.0.offxml"
+    )
+    protocol_settings.thermo_settings.temperature = 298.15 * OFFUnit.kelvin
+    protocol_settings.thermo_settings.pressure = 1 * OFFUnit.bar
+    protocol_settings.protocol_repeats = 1
+
+    return protocol_settings
+
+
 #: Builders that produce the ASAP-Alchemy default settings for a protocol. Where a
 #: protocol is absent, the protocol's own ``default_settings()`` is used unchanged.
 _DEFAULT_SETTINGS_BUILDERS = {
     "RelativeHybridTopologyProtocol": _asap_relative_hybrid_topology_settings,
+    "SepTopProtocol": _asap_septop_settings,
+    "AbsoluteBindingProtocol": _asap_absolute_binding_settings,
 }
 
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/protocols.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/protocols.py
@@ -29,6 +29,10 @@ class _ProtocolRegistration(NamedTuple):
     #: True for node-based protocols (ABFE: one Transformation per ligand, no mapping);
     #: False for edge-based protocols (RBFE: one Transformation per ligand *pair*).
     is_node_protocol: bool = False
+    #: True when the protocol requires separate complex and solvent Transformations
+    #: (e.g. RFE, NEQ); False when the protocol handles both legs internally from a
+    #: single complex-phase Transformation and returns ΔΔG directly (e.g. SepTop).
+    needs_solvent_leg: bool = True
 
 
 #: Index of the alchemical protocols ASAP-Alchemy knows how to build.
@@ -44,6 +48,7 @@ PROTOCOL_REGISTRY: dict[str, _ProtocolRegistration] = {
         module="openfe.protocols.openmm_septop",
         protocol_class="SepTopProtocol",
         package="openfe",
+        needs_solvent_leg=False,
     ),
     "NonEquilibriumCyclingProtocol": _ProtocolRegistration(
         module="feflow.protocols",
@@ -62,6 +67,27 @@ PROTOCOL_REGISTRY: dict[str, _ProtocolRegistration] = {
         is_node_protocol=True,
     ),
 }
+
+
+def needs_solvent_leg(name: str) -> bool:
+    """Return ``True`` if ``name`` requires a separate solvent-phase Transformation.
+
+    Most RBFE protocols (RFE, NEQ) need two ``Transformation``s per edge — one
+    complex and one solvent — and combine them as ΔΔG = ΔG_complex − ΔG_solvent.
+    ``SepTopProtocol`` runs both legs inside a single complex-phase ``Transformation``
+    and returns ΔΔG directly from ``get_estimate()``, so no separate solvent
+    ``Transformation`` should be created.
+
+    Raises:
+        KeyError: If ``name`` is not a registered protocol.
+    """
+    try:
+        return PROTOCOL_REGISTRY[name].needs_solvent_leg
+    except KeyError:
+        raise KeyError(
+            f"Unknown protocol {name!r}; available protocols are "
+            f"{available_protocols()}."
+        )
 
 
 def is_node_protocol(name: str) -> bool:

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/protocols.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/protocols.py
@@ -222,6 +222,23 @@ def _asap_absolute_binding_settings() -> "Settings":
 
     return protocol_settings
 
+def _asap_fah_nonequilibrium_cycling_settings() -> "Settings":
+    """ASAP-tuned default settings for ``FahNonEquilibriumCyclingProtocol``.
+
+    Sets compute platform explicitly to ``None`` to avoid e.g. ``CUDA``
+    failures on the work server.
+    """
+    protocol_class = get_protocol_class("FahNonEquilibriumCyclingProtocol")
+    protocol_settings = protocol_class.default_settings().unfrozen_copy()
+
+    # the default for this setting upstream is `CUDA`;
+    # setting it to `None` will use the fastest platform available on the host,
+    # and not raise an exception if a GPU is not present;
+    # this setting has no bearing on `openm-core` behavior downstream
+    protocol_settings.engine_settings.compute_platform = None
+
+    return protocol_settings
+
 
 #: Builders that produce the ASAP-Alchemy default settings for a protocol. Where a
 #: protocol is absent, the protocol's own ``default_settings()`` is used unchanged.
@@ -229,6 +246,7 @@ _DEFAULT_SETTINGS_BUILDERS = {
     "RelativeHybridTopologyProtocol": _asap_relative_hybrid_topology_settings,
     "SepTopProtocol": _asap_septop_settings,
     "AbsoluteBindingProtocol": _asap_absolute_binding_settings,
+    "FahNonEquilibriumCyclingProtocol": _asap_fah_nonequilibrium_cycling_settings,
 }
 
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
@@ -661,3 +661,170 @@ def test_results_to_cinnabar_with_prediction(tyk2_result_network):
             uncertainty, abs=1e-6
         )
         assert relative_row["source"] == "calculated"
+
+
+# ---------------------------------------------------------------------------
+# SepTopProtocol tests
+# ---------------------------------------------------------------------------
+
+
+def test_fec_septop_network(tyk2_ligands, tyk2_protein):
+    """A SepTopProtocol network has solvent + complex transformations per edge."""
+    factory = FreeEnergyCalculationFactory(protocol=["SepTopProtocol"])
+    planned_network = factory.create_fec_dataset(
+        dataset_name="tyk2-septop", receptor=tyk2_protein, ligands=tyk2_ligands[:3]
+    )
+    alchemical_network = planned_network.to_alchemical_network()
+
+    # every transformation belongs to SepTopProtocol
+    protocol_names = {type(e.protocol).__name__ for e in alchemical_network.edges}
+    assert protocol_names == {"SepTopProtocol"}
+
+    # both solvent and complex legs are present
+    legs = {
+        ("complex" if "protein" in e.stateA.components else "solvent")
+        for e in alchemical_network.edges
+    }
+    assert legs == {"complex", "solvent"}
+
+    # each edge carries an atom mapping
+    for edge in alchemical_network.edges:
+        assert edge.mapping is not None
+
+    # transformation names end with the protocol class name
+    for edge in alchemical_network.edges:
+        assert edge.name.endswith("SepTopProtocol")
+
+
+def test_fec_septop_roundtrip(tyk2_ligands, tyk2_protein, tmp_path):
+    """A SepTopProtocol network survives a to_file/from_file round-trip."""
+    factory = FreeEnergyCalculationFactory(protocol=["SepTopProtocol"])
+    planned = factory.create_fec_dataset(
+        dataset_name="tyk2-septop-rt", receptor=tyk2_protein, ligands=tyk2_ligands[:3]
+    )
+    path = tmp_path / "septop_network.json"
+    planned.to_file(path.as_posix())
+    reloaded = FreeEnergyCalculationNetwork.from_file(path.as_posix())
+
+    assert type(reloaded.protocol_settings["SepTopProtocol"]).__name__ == "SepTopSettings"
+    before = {e.key for e in planned.to_alchemical_network().edges}
+    after = {e.key for e in reloaded.to_alchemical_network().edges}
+    assert before == after
+
+
+def test_fec_rfe_and_septop_combined(tyk2_ligands, tyk2_protein):
+    """RFE and SepTop protocols produce independent transformation sets per edge."""
+    protocols = ["RelativeHybridTopologyProtocol", "SepTopProtocol"]
+    factory = FreeEnergyCalculationFactory(protocol=protocols)
+    planned = factory.create_fec_dataset(
+        dataset_name="tyk2-combined", receptor=tyk2_protein, ligands=tyk2_ligands[:3]
+    )
+    network = planned.to_alchemical_network()
+
+    counts = {"RelativeHybridTopologyProtocol": 0, "SepTopProtocol": 0}
+    for edge in network.edges:
+        counts[type(edge.protocol).__name__] += 1
+
+    assert counts["RelativeHybridTopologyProtocol"] == counts["SepTopProtocol"]
+    assert counts["RelativeHybridTopologyProtocol"] > 0
+    # gufe keys are unique across both protocols
+    keys = [e.key for e in network.edges]
+    assert len(keys) == len(set(keys))
+
+
+# ---------------------------------------------------------------------------
+# AbsoluteBindingProtocol (ABFE) tests
+# ---------------------------------------------------------------------------
+
+
+def test_fec_abfe_network_no_edges(tyk2_ligands, tyk2_protein):
+    """A pure ABFE network has no mapping and iterates over nodes (not edges)."""
+    factory = FreeEnergyCalculationFactory(protocol=["AbsoluteBindingProtocol"])
+    planned = factory.create_fec_dataset(
+        dataset_name="tyk2-abfe", receptor=tyk2_protein, ligands=tyk2_ligands[:3]
+    )
+    network = planned.to_alchemical_network()
+
+    # every transformation belongs to AbsoluteBindingProtocol
+    protocol_names = {type(e.protocol).__name__ for e in network.edges}
+    assert protocol_names == {"AbsoluteBindingProtocol"}
+
+    # no atom mapping (ligand is annihilated, not transformed to another)
+    for edge in network.edges:
+        assert edge.mapping is None
+
+    # stateB has no ligand; stateA does
+    for edge in network.edges:
+        assert "ligand" in edge.stateA.components
+        assert "ligand" not in edge.stateB.components
+
+    # one complex + one solvent transformation per ligand
+    n_ligands = 3
+    assert len(network.edges) == n_ligands * 2
+
+    # gufe keys are unique
+    keys = [e.key for e in network.edges]
+    assert len(keys) == len(set(keys))
+
+
+def test_fec_abfe_roundtrip(tyk2_ligands, tyk2_protein, tmp_path):
+    """An ABFE network survives a to_file/from_file round-trip."""
+    factory = FreeEnergyCalculationFactory(protocol=["AbsoluteBindingProtocol"])
+    planned = factory.create_fec_dataset(
+        dataset_name="tyk2-abfe-rt", receptor=tyk2_protein, ligands=tyk2_ligands[:3]
+    )
+    path = tmp_path / "abfe_network.json"
+    planned.to_file(path.as_posix())
+    reloaded = FreeEnergyCalculationNetwork.from_file(path.as_posix())
+
+    assert (
+        type(reloaded.protocol_settings["AbsoluteBindingProtocol"]).__name__
+        == "AbsoluteBindingSettings"
+    )
+    before = {e.key for e in planned.to_alchemical_network().edges}
+    after = {e.key for e in reloaded.to_alchemical_network().edges}
+    assert before == after
+
+
+def test_fec_rbfe_and_abfe_combined(tyk2_ligands, tyk2_protein):
+    """RBFE and ABFE protocols coexist in the same AlchemicalNetwork."""
+    protocols = ["RelativeHybridTopologyProtocol", "AbsoluteBindingProtocol"]
+    factory = FreeEnergyCalculationFactory(protocol=protocols)
+    planned = factory.create_fec_dataset(
+        dataset_name="tyk2-mixed", receptor=tyk2_protein, ligands=tyk2_ligands[:3]
+    )
+    network = planned.to_alchemical_network()
+
+    rbfe_edges = [e for e in network.edges if type(e.protocol).__name__ == "RelativeHybridTopologyProtocol"]
+    abfe_edges = [e for e in network.edges if type(e.protocol).__name__ == "AbsoluteBindingProtocol"]
+
+    assert len(rbfe_edges) > 0
+    assert len(abfe_edges) > 0
+
+    # RBFE edges have mappings; ABFE edges do not
+    for edge in rbfe_edges:
+        assert edge.mapping is not None
+    for edge in abfe_edges:
+        assert edge.mapping is None
+
+    # ABFE stateB has no ligand
+    for edge in abfe_edges:
+        assert "ligand" not in edge.stateB.components
+
+    # all keys are unique
+    keys = [e.key for e in network.edges]
+    assert len(keys) == len(set(keys))
+
+
+def test_abfe_transformation_result_name():
+    """ABFE TransformationResult.name() returns just ligand_a when ligand_b is None."""
+    from openff.units import unit as OFFUnit
+    result = TransformationResult(
+        ligand_a="mylig",
+        ligand_b=None,
+        phase="complex",
+        estimate=1.0 * OFFUnit.kilocalorie_per_mole,
+        uncertainty=0.1 * OFFUnit.kilocalorie_per_mole,
+        protocol="AbsoluteBindingProtocol",
+    )
+    assert result.name() == "mylig"

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
@@ -669,7 +669,11 @@ def test_results_to_cinnabar_with_prediction(tyk2_result_network):
 
 
 def test_fec_septop_network(tyk2_ligands, tyk2_protein):
-    """A SepTopProtocol network has solvent + complex transformations per edge."""
+    """A SepTopProtocol network has exactly one complex-phase Transformation per edge.
+
+    SepTopProtocol handles both legs (complex and solvent) internally from a single
+    Transformation; no separate solvent Transformation is created.
+    """
     factory = FreeEnergyCalculationFactory(protocol=["SepTopProtocol"])
     planned_network = factory.create_fec_dataset(
         dataset_name="tyk2-septop", receptor=tyk2_protein, ligands=tyk2_ligands[:3]
@@ -680,12 +684,11 @@ def test_fec_septop_network(tyk2_ligands, tyk2_protein):
     protocol_names = {type(e.protocol).__name__ for e in alchemical_network.edges}
     assert protocol_names == {"SepTopProtocol"}
 
-    # both solvent and complex legs are present
-    legs = {
-        ("complex" if "protein" in e.stateA.components else "solvent")
-        for e in alchemical_network.edges
-    }
-    assert legs == {"complex", "solvent"}
+    # SepTop uses only the complex phase (protein in both stateA and stateB); no
+    # separate solvent-only Transformation should be present.
+    for edge in alchemical_network.edges:
+        assert "protein" in edge.stateA.components, "SepTop stateA must have ProteinComponent"
+        assert "protein" in edge.stateB.components, "SepTop stateB must have ProteinComponent"
 
     # each edge carries an atom mapping
     for edge in alchemical_network.edges:
@@ -713,7 +716,12 @@ def test_fec_septop_roundtrip(tyk2_ligands, tyk2_protein, tmp_path):
 
 
 def test_fec_rfe_and_septop_combined(tyk2_ligands, tyk2_protein):
-    """RFE and SepTop protocols produce independent transformation sets per edge."""
+    """RFE and SepTop protocols produce independent transformation sets per edge.
+
+    RFE produces two Transformations per graph-edge (complex + solvent), while
+    SepTopProtocol produces one (combined).  For N graph-edges the network should
+    therefore contain 2*N RFE Transformations and N SepTop Transformations.
+    """
     protocols = ["RelativeHybridTopologyProtocol", "SepTopProtocol"]
     factory = FreeEnergyCalculationFactory(protocol=protocols)
     planned = factory.create_fec_dataset(
@@ -725,8 +733,9 @@ def test_fec_rfe_and_septop_combined(tyk2_ligands, tyk2_protein):
     for edge in network.edges:
         counts[type(edge.protocol).__name__] += 1
 
-    assert counts["RelativeHybridTopologyProtocol"] == counts["SepTopProtocol"]
-    assert counts["RelativeHybridTopologyProtocol"] > 0
+    # RFE: 2 Transformations per graph-edge; SepTop: 1 Transformation per graph-edge
+    assert counts["RelativeHybridTopologyProtocol"] == 2 * counts["SepTopProtocol"]
+    assert counts["SepTopProtocol"] > 0
     # gufe keys are unique across both protocols
     keys = [e.key for e in network.edges]
     assert len(keys) == len(set(keys))

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
@@ -852,6 +852,98 @@ def test_abfe_transformation_result_name():
     assert result.name() == "mylig"
 
 
+def test_abfe_to_cinnabar_absolute_measurement(tyk2_result_network):
+    """ABFE (combined, ``ligand_b is None``) results convert to an *absolute*
+    cinnabar measurement.
+
+    ``cinnabar.AbsoluteMeasurement`` does not exist (verified against cinnabar
+    0.6.1 — the package exports only ``Measurement`` and ``ReferenceState``).  An
+    absolute value is expressed idiomatically as a ``Measurement`` anchored at a
+    true-ground ``ReferenceState``: ``labelA=ReferenceState()``, ``labelB=<ligand>``.
+    """
+    from cinnabar import Measurement, ReferenceState
+
+    abfe_result = TransformationResult(
+        ligand_a="lig_a",
+        ligand_b=None,
+        phase="combined",
+        estimate=-9.0 * OFFUnit.kilocalorie_per_mole,
+        uncertainty=0.3 * OFFUnit.kilocalorie_per_mole,
+        protocol="AbsoluteBindingProtocol",
+    )
+
+    # Rebuild the network with our ABFE result (models are frozen, use model_validate).
+    data = tyk2_result_network.model_dump()
+    data["results"]["results"] = [abfe_result.model_dump()]
+    network = FreeEnergyCalculationNetwork.model_validate(data)
+
+    measurements = network.results.to_cinnabar_measurements()
+    assert len(measurements) == 1
+    measurement = measurements[0]
+
+    # absolute measurement: A-side is the true-ground reference, B-side the ligand
+    assert isinstance(measurement, Measurement)
+    assert isinstance(measurement.labelA, ReferenceState)
+    assert measurement.labelA.is_true_ground()
+    assert measurement.labelB == "lig_a"
+    assert measurement.DG.m_as(OFFUnit.kilocalorie_per_mole) == pytest.approx(-9.0)
+    assert measurement.uncertainty.m_as(OFFUnit.kilocalorie_per_mole) == pytest.approx(
+        0.3
+    )
+    assert measurement.computational
+
+    # the absolute measurement must be ingestible by a cinnabar FEMap (it anchors
+    # the graph on the ligand rather than introducing a spurious sentinel node)
+    fe_map = network.results.to_fe_map()
+    assert fe_map.n_measurements == 1
+    assert fe_map.ligands == ["lig_a"]
+
+
+def test_abfe_two_leg_to_cinnabar_absolute_measurement(tyk2_result_network):
+    """Two-leg ABFE results (complex + solvent, ``ligand_b is None``) combine to an
+    absolute cinnabar ``Measurement`` anchored at a ``ReferenceState`` with
+    ``ΔG = ΔG_complex − ΔG_solvent``."""
+    from cinnabar import Measurement, ReferenceState
+
+    abfe_results = [
+        TransformationResult(
+            ligand_a="lig_a",
+            ligand_b=None,
+            phase="complex",
+            estimate=-12.0 * OFFUnit.kilocalorie_per_mole,
+            uncertainty=0.3 * OFFUnit.kilocalorie_per_mole,
+            protocol="AbsoluteBindingProtocol",
+        ),
+        TransformationResult(
+            ligand_a="lig_a",
+            ligand_b=None,
+            phase="solvent",
+            estimate=-3.0 * OFFUnit.kilocalorie_per_mole,
+            uncertainty=0.4 * OFFUnit.kilocalorie_per_mole,
+            protocol="AbsoluteBindingProtocol",
+        ),
+    ]
+
+    data = tyk2_result_network.model_dump()
+    data["results"]["results"] = [r.model_dump() for r in abfe_results]
+    network = FreeEnergyCalculationNetwork.model_validate(data)
+
+    measurements = network.results.to_cinnabar_measurements()
+    assert len(measurements) == 1
+    measurement = measurements[0]
+
+    assert isinstance(measurement, Measurement)
+    assert isinstance(measurement.labelA, ReferenceState)
+    assert measurement.labelA.is_true_ground()
+    assert measurement.labelB == "lig_a"
+    # ΔG_bind = ΔG_complex − ΔG_solvent = -12.0 − (-3.0) = -9.0
+    assert measurement.DG.m_as(OFFUnit.kilocalorie_per_mole) == pytest.approx(-9.0)
+    # uncertainty combines in quadrature: sqrt(0.3**2 + 0.4**2) = 0.5
+    assert measurement.uncertainty.m_as(OFFUnit.kilocalorie_per_mole) == pytest.approx(
+        0.5
+    )
+
+
 def test_clean_result_network_combined_phase(tyk2_result_network, tmp_path):
     """clean_result_network must not crash on combined-phase (SepTop/ABFE) results
     and must correctly apply the outlier threshold to the estimate directly."""

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
@@ -747,7 +747,13 @@ def test_fec_rfe_and_septop_combined(tyk2_ligands, tyk2_protein):
 
 
 def test_fec_abfe_network_no_edges(tyk2_ligands, tyk2_protein):
-    """A pure ABFE network has no mapping and iterates over nodes (not edges)."""
+    """A pure ABFE network produces exactly one Transformation per ligand.
+
+    AbsoluteBindingProtocol handles both complex and solvent legs internally from a
+    single Transformation (same architecture as SepTopProtocol).  Its
+    _validate_endstates() requires ProteinComponent in both stateA and stateB, so
+    stateB is the apo protein (no ligand) rather than a bare solvent box.
+    """
     factory = FreeEnergyCalculationFactory(protocol=["AbsoluteBindingProtocol"])
     planned = factory.create_fec_dataset(
         dataset_name="tyk2-abfe", receptor=tyk2_protein, ligands=tyk2_ligands[:3]
@@ -762,14 +768,16 @@ def test_fec_abfe_network_no_edges(tyk2_ligands, tyk2_protein):
     for edge in network.edges:
         assert edge.mapping is None
 
-    # stateB has no ligand; stateA does
+    # stateA has ligand + protein; stateB has protein but no ligand (apo)
     for edge in network.edges:
         assert "ligand" in edge.stateA.components
         assert "ligand" not in edge.stateB.components
+        assert "protein" in edge.stateA.components
+        assert "protein" in edge.stateB.components
 
-    # one complex + one solvent transformation per ligand
+    # exactly one Transformation per ligand (both legs handled internally)
     n_ligands = 3
-    assert len(network.edges) == n_ligands * 2
+    assert len(network.edges) == n_ligands
 
     # gufe keys are unique
     keys = [e.key for e in network.edges]
@@ -796,7 +804,11 @@ def test_fec_abfe_roundtrip(tyk2_ligands, tyk2_protein, tmp_path):
 
 
 def test_fec_rbfe_and_abfe_combined(tyk2_ligands, tyk2_protein):
-    """RBFE and ABFE protocols coexist in the same AlchemicalNetwork."""
+    """RBFE and ABFE protocols coexist in the same AlchemicalNetwork.
+
+    RFE: 2 Transformations per graph-edge (complex + solvent).
+    ABFE: 1 Transformation per ligand-node (both legs handled internally).
+    """
     protocols = ["RelativeHybridTopologyProtocol", "AbsoluteBindingProtocol"]
     factory = FreeEnergyCalculationFactory(protocol=protocols)
     planned = factory.create_fec_dataset(
@@ -808,7 +820,8 @@ def test_fec_rbfe_and_abfe_combined(tyk2_ligands, tyk2_protein):
     abfe_edges = [e for e in network.edges if type(e.protocol).__name__ == "AbsoluteBindingProtocol"]
 
     assert len(rbfe_edges) > 0
-    assert len(abfe_edges) > 0
+    # one ABFE Transformation per ligand (3 ligands)
+    assert len(abfe_edges) == 3
 
     # RBFE edges have mappings; ABFE edges do not
     for edge in rbfe_edges:
@@ -816,9 +829,10 @@ def test_fec_rbfe_and_abfe_combined(tyk2_ligands, tyk2_protein):
     for edge in abfe_edges:
         assert edge.mapping is None
 
-    # ABFE stateB has no ligand
+    # ABFE: stateA has ligand+protein, stateB has protein but no ligand (apo)
     for edge in abfe_edges:
         assert "ligand" not in edge.stateB.components
+        assert "protein" in edge.stateB.components
 
     # all keys are unique
     keys = [e.key for e in network.edges]
@@ -831,7 +845,7 @@ def test_abfe_transformation_result_name():
     result = TransformationResult(
         ligand_a="mylig",
         ligand_b=None,
-        phase="complex",
+        phase="combined",
         estimate=1.0 * OFFUnit.kilocalorie_per_mole,
         uncertainty=0.1 * OFFUnit.kilocalorie_per_mole,
         protocol="AbsoluteBindingProtocol",

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
@@ -841,7 +841,6 @@ def test_fec_rbfe_and_abfe_combined(tyk2_ligands, tyk2_protein):
 
 def test_abfe_transformation_result_name():
     """ABFE TransformationResult.name() returns just ligand_a when ligand_b is None."""
-    from openff.units import unit as OFFUnit
     result = TransformationResult(
         ligand_a="mylig",
         ligand_b=None,
@@ -851,3 +850,44 @@ def test_abfe_transformation_result_name():
         protocol="AbsoluteBindingProtocol",
     )
     assert result.name() == "mylig"
+
+
+def test_clean_result_network_combined_phase(tyk2_result_network, tmp_path):
+    """clean_result_network must not crash on combined-phase (SepTop/ABFE) results
+    and must correctly apply the outlier threshold to the estimate directly."""
+    from asapdiscovery.alchemy.predict import clean_result_network
+    from asapdiscovery.alchemy.schema.fec import AlchemiscaleResults
+
+    # Build mock combined-phase results: one within threshold, one outlier.
+    combined_results = [
+        TransformationResult(
+            ligand_a="lig_a",
+            ligand_b="lig_b",
+            phase="combined",
+            estimate=2.0 * OFFUnit.kilocalorie_per_mole,
+            uncertainty=0.1 * OFFUnit.kilocalorie_per_mole,
+            protocol="SepTopProtocol",
+        ),
+        TransformationResult(
+            ligand_a="lig_c",
+            ligand_b="lig_d",
+            phase="combined",
+            estimate=999.0 * OFFUnit.kilocalorie_per_mole,  # outlier
+            uncertainty=0.1 * OFFUnit.kilocalorie_per_mole,
+            protocol="SepTopProtocol",
+        ),
+    ]
+
+    # Rebuild the network with our combined results (models are frozen, use model_validate).
+    data = tyk2_result_network.model_dump()
+    data["results"]["results"] = [r.model_dump() for r in combined_results]
+    network_with_combined = FreeEnergyCalculationNetwork.model_validate(data)
+
+    # clean_result_network expects a file path.
+    network_file = tmp_path / "combined_network.json"
+    network_with_combined.to_file(network_file.as_posix())
+
+    cleaned = clean_result_network(network_file.as_posix(), ddg_outlier_threshold=100.0)
+    kept = cleaned.results.results
+    assert len(kept) == 1
+    assert kept[0].ligand_a == "lig_a"

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_protocols.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_protocols.py
@@ -9,6 +9,7 @@ from asapdiscovery.alchemy.schema.protocols import (
     build_protocol,
     default_protocol_settings,
     get_protocol_class,
+    is_node_protocol,
     protocol_name_for,
 )
 
@@ -16,8 +17,40 @@ from asapdiscovery.alchemy.schema.protocols import (
 def test_available_protocols():
     names = available_protocols()
     assert "RelativeHybridTopologyProtocol" in names
+    assert "SepTopProtocol" in names
+    assert "AbsoluteBindingProtocol" in names
     assert "NonEquilibriumCyclingProtocol" in names
     assert "FahNonEquilibriumCyclingProtocol" in names
+
+
+def test_is_node_protocol():
+    """Edge-based protocols return False; ABFE returns True."""
+    assert not is_node_protocol("RelativeHybridTopologyProtocol")
+    assert not is_node_protocol("SepTopProtocol")
+    assert is_node_protocol("AbsoluteBindingProtocol")
+
+
+def test_is_node_protocol_unknown_raises():
+    with pytest.raises(KeyError, match="Unknown protocol"):
+        is_node_protocol("NotAProtocol")
+
+
+def test_septop_default_settings():
+    """SepTopProtocol defaults include the ASAP force field and one repeat."""
+    settings = default_protocol_settings("SepTopProtocol")
+    assert (
+        settings.forcefield_settings.small_molecule_forcefield == "openff-2.2.0.offxml"
+    )
+    assert settings.protocol_repeats == 1
+
+
+def test_abfe_default_settings():
+    """AbsoluteBindingProtocol defaults include the ASAP force field and one repeat."""
+    settings = default_protocol_settings("AbsoluteBindingProtocol")
+    assert (
+        settings.forcefield_settings.small_molecule_forcefield == "openff-2.2.0.offxml"
+    )
+    assert settings.protocol_repeats == 1
 
 
 @pytest.mark.parametrize("name", available_protocols())

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_protocols.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_protocols.py
@@ -52,6 +52,10 @@ def test_abfe_default_settings():
     )
     assert settings.protocol_repeats == 1
 
+def test_fah_nonequilibrium_cycling_default_settings():
+    """FahNonEquilibriumCyclingProtocol settings set compute platform to ``None``"""
+    settings = default_protocol_settings("FahNonEquilibriumCyclingProtocol")
+    assert settings.engine_settings.compute_platform is None
 
 @pytest.mark.parametrize("name", available_protocols())
 def test_build_and_roundtrip_name(name):

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -13,7 +13,7 @@ from asapdiscovery.alchemy.schema.fec import (
     TransformationResult,
 )
 from asapdiscovery.alchemy.schema.forcefield import ForceFieldParams
-from asapdiscovery.alchemy.schema.protocols import protocol_name_for
+from asapdiscovery.alchemy.schema.protocols import needs_solvent_leg, protocol_name_for
 
 if TYPE_CHECKING:
     from openff.bespokefit.workflows import BespokeWorkflowFactory
@@ -331,7 +331,14 @@ class AlchemiscaleHelper:
                 )
                 continue
 
-            phase = "complex" if "protein" in stateA_components else "solvent"
+            if protocol and not needs_solvent_leg(protocol):
+                # Protocols like SepTopProtocol handle both complex and solvent legs
+                # internally from a single Transformation and return ΔΔG directly from
+                # get_estimate(); the result should not be split or combined with a
+                # second leg.
+                phase = "combined"
+            else:
+                phase = "complex" if "protein" in stateA_components else "solvent"
 
             name_a = stateA_components["ligand"].name or stateA_components["ligand"].smiles
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -308,20 +308,22 @@ class AlchemiscaleHelper:
             else:
                 phase = "solvent"
 
-            # extract the names of the end state ligands to build the affinity estimate graph
-            name_a = individual_runs[0][0].inputs["stateA"].components["ligand"].name
-            name_b = individual_runs[0][0].inputs["stateB"].components["ligand"].name
-            # print(individual_runs[0][0].inputs["stateB"].components["ligand"], name_b)
+            # extract the name of the ligand in stateA; stateB may have no ligand
+            # for node-based (ABFE) protocols where the ligand is annihilated
+            stateA_components = individual_runs[0][0].inputs["stateA"].components
+            stateB_components = individual_runs[0][0].inputs["stateB"].components
 
-            # if end state ligands did not have names, use SMILES instead
+            name_a = stateA_components["ligand"].name
             if not name_a:
-                name_a = (
-                    individual_runs[0][0].inputs["stateA"].components["ligand"].smiles
-                )
-            if not name_b:
-                name_b = (
-                    individual_runs[0][0].inputs["stateB"].components["ligand"].smiles
-                )
+                name_a = stateA_components["ligand"].smiles
+
+            if "ligand" in stateB_components:
+                name_b = stateB_components["ligand"].name
+                if not name_b:
+                    name_b = stateB_components["ligand"].smiles
+            else:
+                # ABFE: stateB has no ligand (annihilated)
+                name_b = None
 
             results.append(
                 TransformationResult(

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -259,6 +259,7 @@ class AlchemiscaleHelper:
             )
 
         key_to_protocol = {}
+        key_to_transformation = {}
         if planned_network:
             network_key = planned_network.results.network_key
 
@@ -268,9 +269,17 @@ class AlchemiscaleHelper:
             # We must rebuild (rather than parse the protocol-suffixed transformation
             # name) because the bespoke-force-field injection feeds into the key, so a
             # faithful map requires the same transformations that were submitted.
+            alchemical_network = planned_network.to_alchemical_network()
             key_to_protocol = {
                 edge.key: protocol_name_for(edge.protocol)
-                for edge in planned_network.to_alchemical_network().edges
+                for edge in alchemical_network.edges
+            }
+            # also map each key to the Transformation itself so we can read
+            # stateA/stateB without touching raw protocol unit result internals —
+            # the unit result data layout varies between protocols (OpenMM DAG vs
+            # feflow NEQ numpy arrays) so we cannot rely on it for component lookup.
+            key_to_transformation = {
+                edge.key: edge for edge in alchemical_network.edges
             }
 
         alchemiscale_network_results = self._client.get_network_results(
@@ -295,32 +304,39 @@ class AlchemiscaleHelper:
             # fall back to the per-unit MBAR error. `unit_estimate_error` is an
             # RFE-specific output; other protocols (e.g. feflow's NEQ cycling) do not
             # provide it, so only use it when present to avoid a KeyError.
+            # Guard with hasattr/try because different protocols have different
+            # ProtocolResult.data layouts (OpenMM DAG results vs NEQ numpy arrays).
             if uncertainty.m == 0.0:
-                unit_results = [edge[0] for edge in raw_result.data.values()]
-                if unit_results and "unit_estimate_error" in unit_results[0].outputs:
-                    uncertainty = unit_results[0].outputs["unit_estimate_error"]
+                try:
+                    unit_results = [edge[0] for edge in raw_result.data.values()]
+                    if unit_results and hasattr(unit_results[0], "outputs") and "unit_estimate_error" in unit_results[0].outputs:
+                        uncertainty = unit_results[0].outputs["unit_estimate_error"]
+                except (AttributeError, TypeError, KeyError):
+                    pass
 
-            # work out the name of the molecules and the phase of the calculation
-            individual_runs = list(raw_result.data.values())
-            # track the phase to correctly work out the total relative energy as complex - solvent
-            if "protein" in individual_runs[0][0].inputs["stateA"].components:
-                phase = "complex"
+            # Read phase and ligand names from the planned Transformation's ChemicalSystems
+            # rather than from raw protocol unit result internals.  The unit result data
+            # layout differs across protocols (OpenMM ProtocolUnitResult objects for
+            # RFE/SepTop/ABFE, numpy work arrays for feflow NEQ) so parsing unit inputs
+            # is not portable.  The planned network's Transformation objects always carry
+            # the full stateA/stateB ChemicalSystems regardless of protocol.
+            transformation = key_to_transformation.get(transformation_key.gufe_key)
+            if transformation is not None:
+                stateA_components = transformation.stateA.components
+                stateB_components = transformation.stateB.components
             else:
-                phase = "solvent"
+                warnings.warn(
+                    f"Could not find transformation {transformation_key} in the local "
+                    "network; skipping this result."
+                )
+                continue
 
-            # extract the name of the ligand in stateA; stateB may have no ligand
-            # for node-based (ABFE) protocols where the ligand is annihilated
-            stateA_components = individual_runs[0][0].inputs["stateA"].components
-            stateB_components = individual_runs[0][0].inputs["stateB"].components
+            phase = "complex" if "protein" in stateA_components else "solvent"
 
-            name_a = stateA_components["ligand"].name
-            if not name_a:
-                name_a = stateA_components["ligand"].smiles
+            name_a = stateA_components["ligand"].name or stateA_components["ligand"].smiles
 
             if "ligand" in stateB_components:
-                name_b = stateB_components["ligand"].name
-                if not name_b:
-                    name_b = stateB_components["ligand"].smiles
+                name_b = stateB_components["ligand"].name or stateB_components["ligand"].smiles
             else:
                 # ABFE: stateB has no ligand (annihilated)
                 name_b = None

--- a/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
@@ -271,7 +271,7 @@ class Ligand(DataModelAbstractBase):
         """
         mol = sdf_string_to_oemol(self.data)
         data = {}
-        for key in self.model_fields.keys():
+        for key in self.__class__.model_fields.keys():
             if key not in ["data", "tags", "conf_tags", "data_format"]:
                 field = getattr(self, key)
                 try:
@@ -355,7 +355,7 @@ class Ligand(DataModelAbstractBase):
 
         rdkit_mol: Chem.Mol = sdf_str_to_rdkit_mol(self.data)
         data = {}
-        for key in self.model_fields.keys():
+        for key in self.__class__.model_fields.keys():
             if key not in ["data", "tags", "data_format", "conf_tags"]:
                 field = getattr(self, key)
                 try:
@@ -554,7 +554,7 @@ class Ligand(DataModelAbstractBase):
         # and ensure that the length of the data matches the number of conformers
         new_data = {}
         for k, v in data.items():
-            if k in self.model_fields.keys():
+            if k in self.__class__.model_fields.keys():
                 warnings.warn(f"Tag name {k} is a reserved attribute name, skipping")
             else:
                 # if list is len 1, generate a list of len N, where N is the number of conformers


### PR DESCRIPTION
## Description
Given merged https://github.com/asapdiscovery/asapdiscovery/pull/1304, registers two new alchemical protocols: 

SepTopProtocol (separated topologies, edge-based RBFE) and AbsoluteBindingProtocol (node-based ABFE) — both from `openfe`.

Extends the multi-protocol infrastructure to handle node-based protocols (ABFE), which operate on individual ligands rather than ligand pairs
Suppresses a collection of persistent third-party deprecation warnings in the CLI

- [ ] run and analyze pan-protocol run on TYK2 

 
## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/asapdiscovery/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
